### PR TITLE
Ajoute un modèle pour stocker les communes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
+gem "rails-i18n", "~> 7.0.0"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
@@ -80,4 +81,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webmock"
   gem "simplecov", require: false
+  gem "shoulda-matchers", "~> 6.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -361,6 +364,8 @@ GEM
     sentry-ruby (5.17.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    shoulda-matchers (6.2.0)
+      activesupport (>= 5.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -455,11 +460,13 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n (~> 7.0.0)
   rspec-rails (~> 6.1.0)
   rubocop-rails
   selenium-webdriver
   sentry-rails
   sentry-ruby
+  shoulda-matchers (~> 6.0)
   simplecov
   spring
   spring-commands-rspec

--- a/app/controllers/collectivities_controller.rb
+++ b/app/controllers/collectivities_controller.rb
@@ -1,4 +1,5 @@
 class CollectivitiesController < ApplicationController
   def index
+    @collectivities = Collectivity.active
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,4 @@
 class HomeController < ApplicationController
-  def home
+  def index
   end
 end

--- a/app/models/collectivity.rb
+++ b/app/models/collectivity.rb
@@ -1,0 +1,4 @@
+class Collectivity < ApplicationRecord
+  enum status: {active: "active", inactive: "inactive"}
+  validates :name, :siret, :code_cog, :status, presence: true
+end

--- a/app/views/collectivities/index.html.erb
+++ b/app/views/collectivities/index.html.erb
@@ -27,7 +27,7 @@
       </span>
     <% end %>
 
-    <%= form.select :recipient, [["Pey", "13002526500013"], ["Une autre", "13002526500013"]] , {}, class: "fr-select" %>
+    <%= form.select :recipient, options_from_collection_for_select(@collectivities, :siret, :name), {}, class: "fr-select" %>
 
     <div class="fr-notice fr-notice--info fr-mt-2w">
       <div class="fr-container">

--- a/db/migrate/20240607130136_create_collectivities.rb
+++ b/db/migrate/20240607130136_create_collectivities.rb
@@ -1,0 +1,13 @@
+class CreateCollectivities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :collectivities do |t|
+      t.string :name
+      t.string :siret
+      t.string :code_cog
+      t.string :status
+      t.string :editor
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_084727) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_130136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "collectivities", force: :cascade do |t|
+    t.string "name"
+    t.string "siret"
+    t.string "code_cog"
+    t.string "status"
+    t.string "editor"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "shipments", force: :cascade do |t|
     t.string "sub"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,12 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+if !Rails.env.production?
+  Collectivity.find_or_create_by!(
+    name: "Majastres",
+    siret: "21040107100019",
+    code_cog: "04107",
+    status: "active"
+  )
+end

--- a/features/accueil.feature
+++ b/features/accueil.feature
@@ -8,5 +8,7 @@ Fonctionnalité: Consulter la page d'accueil
     Alors la page contient "Transmettre son quotient familial à sa collectivité"
 
   Scénario: Je me rends sur la page de collectivités
+    Etant donné l'existence de la commune de Majastres
     Quand je clique sur le premier "Débuter la démarche"
     Alors la page contient "Sélectionner votre commune"
+    Alors la page contient "Majastres"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -2,6 +2,10 @@ Quand("je me rends sur la page d'accueil") do
   visit "/"
 end
 
+Soit("l'existence de la commune de Majastres") do
+  FactoryBot.create(:collectivity, name: "Majastres", siret: "21040107100019", code_cog: "04107", status: "active")
+end
+
 Alors("la page contient {string}") do |content|
   expect(page).to have_content(content)
 end

--- a/spec/factories/collectivities.rb
+++ b/spec/factories/collectivities.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :collectivity do
+    name { "Commune-sur-Brie" }
+    siret { "12345678900042" }
+    code_cog { "40207" }
+    status { "active" }
+  end
+end

--- a/spec/models/collectivity_spec.rb
+++ b/spec/models/collectivity_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Collectivity, type: :model do
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:siret) }
+  it { is_expected.to validate_presence_of(:code_cog) }
+  it { is_expected.to validate_presence_of(:status) }
+
+  it { is_expected.to define_enum_for(:status).with_values(active: "active", inactive: "inactive").backed_by_column_of_type(:string) }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,3 +66,9 @@ RSpec.configure do |config|
   config.include QuotientFamilial::Matchers
   config.include ProviderStubs::HubEE
 end
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Ajoute un modèle Collectivity pour stocker les informations des collectivités qui mettent en place le service FormulaireQF.
Ces données servent aussi à configurer les appels vers HubEE.