### PR TITLE
Configure les cookies de session pour expirer après 24h

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, expire_after: 24.hours


### PR DESCRIPTION
Les données des usagers sont conservées dans les cookies de session chiffrés, ces données sont supprimée à la fin de la demande.

Pour protéger nos usagers, cette PR configure l'expiration de ces cookies à 24h permettant ainsi de supprimer ces informations pour des personnes n'ayant pas terminé le processus.