### PR TITLE
Fixe l'invalidation de la session d'auth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
 
   def create
     session[:auth] = request.env["omniauth.auth"]
-    session[:auth]["state"] = params[:state]
+    session["state"] = params[:state]
 
     SetupCurrentData.call(session:, params:)
     result = GetFamilyQuotient.call(recipient: Current.collectivity.siret, user: Current.user)
@@ -24,8 +24,8 @@ class SessionsController < ApplicationController
 
   def destroy
     id_token_hint = session[:auth]["credentials"]["id_token"]
-    state = session[:auth]["state"]
-    url = "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=#{id_token_hint}&post_logout_redirect_uri=#{fc_logout_callback_url}&state=#{state}"
+    state = session["state"]
+    url = "https://#{Settings.france_connect.host}/api/v1/logout?id_token_hint=#{id_token_hint}&post_logout_redirect_uri=#{fc_logout_callback_url}&state=#{state}"
     reset_session
 
     redirect_to url, allow_other_host: true

--- a/features/transmettre_mes_informations.feature
+++ b/features/transmettre_mes_informations.feature
@@ -1,7 +1,8 @@
 # language: fr
 
 Fonctionnalité: Transmettre mes informations
-  Contexte: 
+  Contexte:
+    Etant donné l'existence de la commune de Majastres
     Sachant que j'ai un compte sur FranceConnect
     Et que hubee peut recevoir un dossier
     Et que je me rends sur la page d'accueil


### PR DESCRIPTION
Garde le state open_id_connect dans à la racine de la session et non dans la partie réservée à omniauth (ce qui invalidait les données).

Fixe la feature de transmission des données qui n'avait pas la commune de test créée au préablable.