### PR TITLE
Bugfix: FIX session wipeout by reducing data stored within session

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,8 +4,10 @@ class SessionsController < ApplicationController
   end
 
   def create
-    session[:auth] = request.env["omniauth.auth"]
-    session["state"] = params[:state]
+    session[:raw_info] = request.env["omniauth.auth"]["extra"]["raw_info"]
+    session[:france_connect_token] = request.env["omniauth.auth"]["credentials"]["token"]
+    session[:france_connect_token_hint] = request.env["omniauth.auth"]["credentials"]["id_token"]
+    session[:state] = params[:state]
 
     SetupCurrentData.call(session:, params:)
     result = GetFamilyQuotient.call(recipient: Current.collectivity.siret, user: Current.user)
@@ -23,7 +25,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    id_token_hint = session[:auth]["credentials"]["id_token"]
+    id_token_hint = session[:france_connect_token_hint]
     state = session["state"]
     url = "https://#{Settings.france_connect.host}/api/v1/logout?id_token_hint=#{id_token_hint}&post_logout_redirect_uri=#{fc_logout_callback_url}&state=#{state}"
     reset_session

--- a/app/interactors/setup_current_data.rb
+++ b/app/interactors/setup_current_data.rb
@@ -9,7 +9,7 @@ class SetupCurrentData < BaseInteractor
   private
 
   def pivot_identity
-    PivotIdentity.new(**FranceConnect::IdentityMapper.normalize(session_auth))
+    PivotIdentity.new(**FranceConnect::IdentityMapper.normalize(session_raw_info))
   end
 
   def quotient_familial
@@ -21,11 +21,11 @@ class SetupCurrentData < BaseInteractor
     Collectivity.find_by(siret: siret) || Collectivity.new
   end
 
-  def session_auth
-    context.session.fetch("auth", {})
+  def session_raw_info
+    context.session.fetch("raw_info", {})
   end
 
   def user
-    User.new(**FranceConnect::AuthMapper.normalize(session_auth))
+    User.new(**FranceConnect::AuthMapper.normalize(session_raw_info).merge(access_token: context.session[:france_connect_token]))
   end
 end

--- a/app/mappers/france_connect/auth_mapper.rb
+++ b/app/mappers/france_connect/auth_mapper.rb
@@ -2,9 +2,8 @@ module FranceConnect
   class AuthMapper
     extend HashMapper
 
-    map from("credentials/token"), to("access_token")
-    map from("extra/raw_info/sub"), to("sub")
-    map from("extra/raw_info/family_name"), to("last_name")
-    map from("extra/raw_info/given_name"), to("first_names")
+    map from("sub"), to("sub")
+    map from("family_name"), to("last_name")
+    map from("given_name"), to("first_names")
   end
 end

--- a/app/mappers/france_connect/identity_mapper.rb
+++ b/app/mappers/france_connect/identity_mapper.rb
@@ -2,11 +2,11 @@ module FranceConnect
   class IdentityMapper
     extend HashMapper
 
-    map from("extra/raw_info/birthcountry"), to("birth_country")
-    map from("extra/raw_info/birthdate"), to("birthdate") { |str| Date.strptime(str, "%Y-%m-%d") }
-    map from("extra/raw_info/birthplace"), to("birthplace")
-    map from("extra/raw_info/family_name"), to("last_name")
-    map from("extra/raw_info/given_name"), to("first_names") { |str| str.split(" ") }
-    map from("extra/raw_info/gender"), to("gender") { |str| str.to_sym }
+    map from("birthcountry"), to("birth_country")
+    map from("birthdate"), to("birthdate") { |str| Date.strptime(str, "%Y-%m-%d") }
+    map from("birthplace"), to("birthplace")
+    map from("family_name"), to("last_name")
+    map from("given_name"), to("first_names") { |str| str.split(" ") }
+    map from("gender"), to("gender") { |str| str.to_sym }
   end
 end

--- a/spec/mappers/france_connect/auth_mapper_spec.rb
+++ b/spec/mappers/france_connect/auth_mapper_spec.rb
@@ -6,21 +6,13 @@ describe FranceConnect::AuthMapper, type: :mapper do
 
     let(:expected_auth) do
       {
-        access_token: "some_real_token",
         sub: "some_real_sub",
       }
     end
 
     let(:payload) do
       {
-        "credentials" => {
-          "token" => "some_real_token",
-        },
-        "extra" => {
-          "raw_info" => {
-            "sub" => "some_real_sub",
-          },
-        },
+        "sub" => "some_real_sub",
       }
     end
 

--- a/spec/mappers/france_connect/identity_mapper_spec.rb
+++ b/spec/mappers/france_connect/identity_mapper_spec.rb
@@ -17,16 +17,12 @@ describe FranceConnect::IdentityMapper, type: :mapper do
 
     let(:payload) do
       {
-        "extra" => {
-          "raw_info" => {
-            "birthcountry" => "France",
-            "birthplace" => "Paris",
-            "birthdate" => "1980-01-01",
-            "family_name" => "Doe",
-            "given_name" => "John",
-            "gender" => "male",
-          },
-        },
+        "birthcountry" => "France",
+        "birthplace" => "Paris",
+        "birthdate" => "1980-01-01",
+        "family_name" => "Doe",
+        "given_name" => "John",
+        "gender" => "male",
       }
     end
 


### PR DESCRIPTION
Because of a strange bug with CookieStore, adding the store of the `state` value from params wiped some keys on the redirect (`auth` and `state`)

Don't know why, but switching session store solves the issue. We can't store personal data on our side (legals related), so we can just reduce the size of what we store from `auth` hash from OmniAuth.

Tried to fix the issue with a non-regression test, but did not manage to fix it..

Manually tested with staging env from FranceConnect, it works.