### PR TITLE
Garde les paramètres passés par l'éditeur en session

### DIFF
--- a/app/controllers/collectivities_controller.rb
+++ b/app/controllers/collectivities_controller.rb
@@ -1,12 +1,12 @@
 class CollectivitiesController < ApplicationController
   before_action :set_collectivity, only: %i[select show]
+  before_action :move_params_to_session, only: :show
 
   def index
     @collectivities = Collectivity.active
   end
 
   def show
-    session["siret"] = @collectivity.siret
   end
 
   def select
@@ -18,6 +18,12 @@ class CollectivitiesController < ApplicationController
   end
 
   private
+
+  def move_params_to_session
+    session[:external_id] ||= params[:external_id]
+    session[:redirect_uri] ||= params[:redirect_uri]
+    session[:siret] ||= @collectivity.siret
+  end
 
   def set_collectivity
     @collectivity = Collectivity.find_by!(siret: params[:id])

--- a/app/controllers/collectivities_controller.rb
+++ b/app/controllers/collectivities_controller.rb
@@ -23,6 +23,7 @@ class CollectivitiesController < ApplicationController
     session[:external_id] ||= params[:external_id]
     session[:redirect_uri] ||= params[:redirect_uri]
     session[:siret] ||= @collectivity.siret
+    SetupCurrentData.call(session: session, params: params)
   end
 
   def set_collectivity

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -3,6 +3,7 @@ class ShipmentsController < ApplicationController
 
   def show
     @shipment = Shipment.find_by(reference: params[:reference])
+    @redirect_uri = session[:redirect_uri]
   end
 
   def new
@@ -12,7 +13,13 @@ class ShipmentsController < ApplicationController
 
   def create
     hubee_recipient = HubEE::Recipient.new(siren: @collectivity.siret, branch_code: "04107")
-    result = StoreQuotientFamilial.call(user: Current.user, pivot_identity: Current.pivot_identity, quotient_familial: Current.quotient_familial, recipient: hubee_recipient)
+    result = StoreQuotientFamilial.call(
+      external_id: session[:external_id],
+      pivot_identity: Current.pivot_identity,
+      quotient_familial: Current.quotient_familial,
+      recipient: hubee_recipient,
+      user: Current.user
+    )
 
     if result.success?
       redirect_to collectivity_shipment_path(@collectivity.siret, result.shipment.reference)

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -3,7 +3,7 @@ class ShipmentsController < ApplicationController
 
   def show
     @shipment = Shipment.find_by(reference: params[:reference])
-    @redirect_uri = session[:redirect_uri]
+    @redirect_uri = Current.redirect_uri
   end
 
   def new
@@ -14,7 +14,7 @@ class ShipmentsController < ApplicationController
   def create
     hubee_recipient = HubEE::Recipient.new(siren: @collectivity.siret, branch_code: "04107")
     result = StoreQuotientFamilial.call(
-      external_id: session[:external_id],
+      external_id: Current.external_id,
       pivot_identity: Current.pivot_identity,
       quotient_familial: Current.quotient_familial,
       recipient: hubee_recipient,

--- a/app/interactors/prepare_quotient_familial_hubee_folder.rb
+++ b/app/interactors/prepare_quotient_familial_hubee_folder.rb
@@ -58,7 +58,7 @@ class PrepareQuotientFamilialHubEEFolder < BaseInteractor
   end
 
   def shipment_data
-    ShipmentData.new(external_id: "test", pivot_identity: context.pivot_identity, quotient_familial: context.quotient_familial)
+    ShipmentData.new(external_id: context.external_id, pivot_identity: context.pivot_identity, quotient_familial: context.quotient_familial)
   end
 
   def xml_file

--- a/app/interactors/setup_current_data.rb
+++ b/app/interactors/setup_current_data.rb
@@ -4,9 +4,19 @@ class SetupCurrentData < BaseInteractor
     Current.quotient_familial = quotient_familial
     Current.collectivity = collectivity
     Current.user = user
+    Current.external_id = external_id
+    Current.redirect_uri = redirect_uri
   end
 
   private
+
+  def external_id
+    context.session[:external_id]
+  end
+
+  def redirect_uri
+    context.session[:redirect_uri]
+  end
 
   def pivot_identity
     PivotIdentity.new(**FranceConnect::IdentityMapper.normalize(session_raw_info))

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :pivot_identity, :quotient_familial, :collectivity, :user
+  attribute :pivot_identity, :quotient_familial, :collectivity, :user, :external_id, :redirect_uri
 end

--- a/app/views/shipments/show.html.erb
+++ b/app/views/shipments/show.html.erb
@@ -4,4 +4,7 @@
   <span class="fr-icon-success-fill big-icon success-green" aria-hidden="true"></span>
   <%= simple_format t('pages.shipments.show.title', label: @collectivity.name, code_cog: @collectivity.code_cog), { }, wrapper_tag: 'h2' %>
   <%= simple_format t('pages.shipments.show.reference', reference: @shipment.reference), class: "fr-text--lead fr-mt-3w" %>
+  <% if @redirect_uri %>
+    <%= link_to t('pages.shipments.show.redirect_cta'), @redirect_uri, class: "fr-btn fr-btn--secondary fr-btn--lg fr-btn--icon-right fr-icon-external-link-line fr-mt-3w" %>
+  <% end %>
 </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -85,6 +85,7 @@ fr:
           paragraph_2: "%{collectivity} conservera vos données d'identité si sa politique tarifaire prévoit une mise à jour régulière du quotient familial. Vous bénéficierez ainsi d'une tarification ajustée au plus prêt de vos ressources."
         next_button: Transmettre mes informations
       show:
+        redirect_cta: Retourner sur le site de ma commune
         reference: |
           <strong>Identifiant de cette démarche,</strong>
           À garder et à transmettre à votre commune en cas de difficulté :

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -6,6 +6,10 @@ Quand("je me rends sur la page d'accueil") do
   visit "/"
 end
 
+Sachantque("j'arrive sur le formulaire depuis le portail de ma commune") do
+  visit "/collectivities/21040107100019?external_id=123&redirect_uri=http://real_uri"
+end
+
 Soit("l'existence de la commune de Majastres") do
   Collectivity.find_by(siret: "21040107100019") ||
     FactoryBot.create(:collectivity, name: "Majastres", siret: "21040107100019", code_cog: "04107", status: "active")

--- a/features/transmettre_mes_informations.feature
+++ b/features/transmettre_mes_informations.feature
@@ -44,3 +44,11 @@ Fonctionnalité: Transmettre mes informations
     Quand je clique sur "Transmettre mes informations"
     Alors la page contient "Vos informations ont bien été transmises à Majastres"
     Et la page contient la référence de ma demande
+    Et la page ne contient pas "Retourner sur le site de ma commune"
+
+  Scénario: Je peux retourner sur le site de ma commune
+    Et que j'arrive sur le formulaire depuis le portail de ma commune
+    Et que j'ai un quotient familial msa avec des enfants
+    Et que je clique sur "S’identifier avec FranceConnect"
+    Quand je clique sur "Transmettre mes informations"
+    Alors la page contient "Retourner sur le site de ma commune"

--- a/spec/interactors/setup_current_data_spec.rb
+++ b/spec/interactors/setup_current_data_spec.rb
@@ -4,7 +4,7 @@ describe SetupCurrentData, type: :interactor do
   describe ".call" do
     subject(:call) { described_class.call(session: session, params: params) }
 
-    let(:session) { {"quotient_familial" => {"quotient_familial" => 2550}} }
+    let(:session) { {:external_id => "12345", :redirect_uri => "https://real_uri", "quotient_familial" => {"quotient_familial" => 2550}} }
     let(:collectivity) { create(:collectivity) }
     let(:params) { {collectivity_id: collectivity.siret} }
 
@@ -13,6 +13,8 @@ describe SetupCurrentData, type: :interactor do
       Current.pivot_identity = nil
       Current.quotient_familial = nil
       Current.collectivity = nil
+      Current.external_id = nil
+      Current.redirect_uri = nil
     end
 
     it "sets up current data" do
@@ -33,6 +35,14 @@ describe SetupCurrentData, type: :interactor do
 
     it "sets up the current collectivity" do
       expect { call }.to change { Current.collectivity }.from(nil).to(collectivity)
+    end
+
+    it "sets up the current external id" do
+      expect { call }.to change { Current.external_id }.from(nil).to("12345")
+    end
+
+    it "sets up the current redirect uri" do
+      expect { call }.to change { Current.redirect_uri }.from(nil).to("https://real_uri")
     end
   end
 end


### PR DESCRIPTION
external_id est transmis à HubEE
redirect_uri est utilisé pour afficher un bouton de retour sur la page de confirmation de la demande