### PR TITLE
Traite les notifications HubEE en tâche de fond

### DIFF
--- a/app/interactors/create_shipment.rb
+++ b/app/interactors/create_shipment.rb
@@ -1,6 +1,7 @@
 class CreateShipment < BaseInteractor
   def call
     shipment = context.shipment
+    shipment.hubee_case_id = context.folder.first_case_id
     shipment.hubee_folder_id = context.folder.id
 
     if !shipment.save

--- a/app/interactors/prepare_quotient_familial_hubee_folder.rb
+++ b/app/interactors/prepare_quotient_familial_hubee_folder.rb
@@ -26,12 +26,18 @@ class PrepareQuotientFamilialHubEEFolder < BaseInteractor
         pdf_file,
       ],
       cases: [
-        external_id: case_external_id,
-        recipient: context.recipient,
+        kase,
       ],
       external_id:,
       process_code:,
     }
+  end
+
+  def kase
+    ::HubEE::Case.new(
+      external_id: case_external_id,
+      recipient: context.recipient
+    )
   end
 
   def json_file

--- a/app/interactors/process_hubee_notification.rb
+++ b/app/interactors/process_hubee_notification.rb
@@ -1,0 +1,44 @@
+class ProcessHubEENotification < BaseInteractor
+  delegate :session, to: :context
+
+  before do
+    context.session = HubEE::Api.session
+  end
+
+  def call
+    return unless notification.formulaire_qf?
+
+    return if notification.new_folder?
+
+    return unless event.valid? && event.sent? && event.status_update?
+
+    find_and_update_shipment if event.processable?
+
+    session.update_event(id: notification.event_id, case_id: notification.case_id)
+  end
+
+  after do
+    session.delete_notification(notification_id: notification.id)
+  end
+
+  private
+
+  def event
+    @event ||= HubEE::Event.new(session.event(id: notification.event_id, case_id: notification.case_id))
+  end
+
+  def find_and_update_shipment
+    return unless shipment
+
+    shipment.update!(hubee_status: event.case_new_status.downcase)
+    shipment.update!(hubee_folder_id: nil, hubee_case_id: nil) if event.final_status?
+  end
+
+  def notification
+    @notification ||= HubEE::Notification.new(context.notification)
+  end
+
+  def shipment
+    @shipment ||= Shipment.find_by(hubee_case_id: notification.case_id)
+  end
+end

--- a/app/interactors/process_hubee_notification.rb
+++ b/app/interactors/process_hubee_notification.rb
@@ -1,16 +1,12 @@
 class ProcessHubEENotification < BaseInteractor
-  delegate :session, to: :context
-
-  before do
-    context.session = HubEE::Api.session
-  end
-
   def call
     return unless notification.formulaire_qf?
 
     return if notification.new_folder?
 
-    return unless event.valid? && event.sent? && event.status_update?
+    return if event.error?
+
+    return unless event.sent? && event.status_update?
 
     find_and_update_shipment if event.processable?
 
@@ -36,6 +32,10 @@ class ProcessHubEENotification < BaseInteractor
 
   def notification
     @notification ||= HubEE::Notification.new(context.notification)
+  end
+
+  def session
+    @session ||= HubEE::Api.session
   end
 
   def shipment

--- a/app/jobs/read_hubee_notifications_job.rb
+++ b/app/jobs/read_hubee_notifications_job.rb
@@ -1,11 +1,11 @@
 class ReadHubEENotificationsJob < ApplicationJob
   queue_as :default
 
-  def perform(items: 100)
-    notifications = HubEE::Api.session.notifications(items:)
+  def perform(items_count: 100)
+    notifications = HubEE::Api.session.notifications(items_count:)
     notifications.each do |notification|
       ProcessHubEENotification.call(notification:)
     end
-    ReadHubEENotificationsJob.perform_later if notifications.size == items
+    ReadHubEENotificationsJob.perform_later if notifications.size == items_count
   end
 end

--- a/app/jobs/read_hubee_notifications_job.rb
+++ b/app/jobs/read_hubee_notifications_job.rb
@@ -1,83 +1,11 @@
 class ReadHubEENotificationsJob < ApplicationJob
   queue_as :default
 
-  class Notification
-    def initialize(notification)
-      @notification = notification
+  def perform(items: 100)
+    notifications = HubEE::Api.session.notifications(items:)
+    notifications.each do |notification|
+      ProcessHubEENotification.call(notification:)
     end
-
-    def case_id
-      @notification["caseId"]
-    end
-
-    def event_id
-      @notification["eventId"]
-    end
-
-    def formulaire_qf?
-      @notification["processCode"] == "FormulaireQF"
-    end
-
-    def id
-      @notification["id"]
-    end
-
-    def new_folder?
-      event_id.blank?
-    end
-  end
-
-  class Event
-    def initialize(event)
-      @event = event
-    end
-
-    def case_current_status
-      @event["caseCurrentStatus"]
-    end
-
-    def received?
-      @event["status"] == "RECEIVED"
-    end
-
-    def sent?
-      @event["status"] == "SENT"
-    end
-
-    def case_new_status
-      @event["caseNewStatus"]
-    end
-
-    def valid?
-      @event["errors"].blank?
-    end
-  end
-
-  def perform(*args)
-    HubEE::Api.session.notifications.each do |notification|
-      notification = Notification.new(notification)
-      # Our process looks like it should be the opposite of the editors'
-      # Q: will we get notifications for other processCodes? In which case... what should we do?
-      if !notification.formulaire_qf?
-        Rails.logger.debug { "NOPE #{notification.id}" }
-        next
-      end
-      if notification.new_folder?
-        # 1. On new folders we should probably mark them as processed and delete the notification
-      else
-        # 2. On existing folders
-        # 3. Get the event
-        event = Event.new(HubEE::Api.session.event(id: notification.event_id, case_id: notification.case_id))
-        # 4. Deal with SENT and RECEIVED event statuses
-        next unless event.valid?
-
-        if event.sent?
-          Rails.logger.debug { "\nSENT #{event.case_current_status} -> #{event.case_new_status}\n" }
-        elsif event.received?
-          # Rails.logger.debug notification
-          HubEE::Api.session.delete_notification(notification_id: notification.id)
-        end
-      end
-    end
+    ReadHubEENotificationsJob.perform_later if notifications.size == items
   end
 end

--- a/app/jobs/read_hubee_notifications_job.rb
+++ b/app/jobs/read_hubee_notifications_job.rb
@@ -1,0 +1,83 @@
+class ReadHubEENotificationsJob < ApplicationJob
+  queue_as :default
+
+  class Notification
+    def initialize(notification)
+      @notification = notification
+    end
+
+    def case_id
+      @notification["caseId"]
+    end
+
+    def event_id
+      @notification["eventId"]
+    end
+
+    def formulaire_qf?
+      @notification["processCode"] == "FormulaireQF"
+    end
+
+    def id
+      @notification["id"]
+    end
+
+    def new_folder?
+      event_id.blank?
+    end
+  end
+
+  class Event
+    def initialize(event)
+      @event = event
+    end
+
+    def case_current_status
+      @event["caseCurrentStatus"]
+    end
+
+    def received?
+      @event["status"] == "RECEIVED"
+    end
+
+    def sent?
+      @event["status"] == "SENT"
+    end
+
+    def case_new_status
+      @event["caseNewStatus"]
+    end
+
+    def valid?
+      @event["errors"].blank?
+    end
+  end
+
+  def perform(*args)
+    HubEE::Api.session.notifications.each do |notification|
+      notification = Notification.new(notification)
+      # Our process looks like it should be the opposite of the editors'
+      # Q: will we get notifications for other processCodes? In which case... what should we do?
+      if !notification.formulaire_qf?
+        Rails.logger.debug { "NOPE #{notification.id}" }
+        next
+      end
+      if notification.new_folder?
+        # 1. On new folders we should probably mark them as processed and delete the notification
+      else
+        # 2. On existing folders
+        # 3. Get the event
+        event = Event.new(HubEE::Api.session.event(id: notification.event_id, case_id: notification.case_id))
+        # 4. Deal with SENT and RECEIVED event statuses
+        next unless event.valid?
+
+        if event.sent?
+          Rails.logger.debug { "\nSENT #{event.case_current_status} -> #{event.case_new_status}\n" }
+        elsif event.received?
+          # Rails.logger.debug notification
+          HubEE::Api.session.delete_notification(notification_id: notification.id)
+        end
+      end
+    end
+  end
+end

--- a/app/models/hubee/case.rb
+++ b/app/models/hubee/case.rb
@@ -1,0 +1,11 @@
+module HubEE
+  class Case < Data.define(:id, :external_id, :recipient)
+    def initialize(external_id:, recipient:, id: nil)
+      super
+    end
+
+    def [](key)
+      public_send(key)
+    end
+  end
+end

--- a/app/models/hubee/event.rb
+++ b/app/models/hubee/event.rb
@@ -7,12 +7,12 @@ module HubEE
       @event = event
     end
 
-    def case_current_status
-      @event["caseCurrentStatus"]
-    end
-
     def case_new_status
       @event["caseNewStatus"]
+    end
+
+    def error?
+      @event["errors"].present?
     end
 
     def final_status?
@@ -21,10 +21,6 @@ module HubEE
 
     def processable?
       PROCESSABLE_EVENTS.include?(case_new_status)
-    end
-
-    def received?
-      status == "RECEIVED"
     end
 
     def sent?
@@ -37,10 +33,6 @@ module HubEE
 
     def status_update?
       @event["actionType"] == "STATUS_UPDATE"
-    end
-
-    def valid?
-      @event["errors"].blank?
     end
   end
 end

--- a/app/models/hubee/event.rb
+++ b/app/models/hubee/event.rb
@@ -1,0 +1,46 @@
+module HubEE
+  class Event
+    FINAL_STATUSES = %w[DONE REFUSED].freeze
+    PROCESSABLE_EVENTS = %w[SENT SI_RECEIVED IN_PROGRESS DONE REFUSED].freeze
+
+    def initialize(event)
+      @event = event
+    end
+
+    def case_current_status
+      @event["caseCurrentStatus"]
+    end
+
+    def case_new_status
+      @event["caseNewStatus"]
+    end
+
+    def final_status?
+      FINAL_STATUSES.include?(case_new_status)
+    end
+
+    def processable?
+      PROCESSABLE_EVENTS.include?(case_new_status)
+    end
+
+    def received?
+      status == "RECEIVED"
+    end
+
+    def sent?
+      status == "SENT"
+    end
+
+    def status
+      @event["status"]
+    end
+
+    def status_update?
+      @event["actionType"] == "STATUS_UPDATE"
+    end
+
+    def valid?
+      @event["errors"].blank?
+    end
+  end
+end

--- a/app/models/hubee/folder.rb
+++ b/app/models/hubee/folder.rb
@@ -7,5 +7,9 @@ module HubEE
     def [](key)
       public_send(key)
     end
+
+    def first_case_id
+      cases.first.id
+    end
   end
 end

--- a/app/models/hubee/notification.rb
+++ b/app/models/hubee/notification.rb
@@ -1,0 +1,27 @@
+module HubEE
+  class Notification
+    def initialize(notification)
+      @notification = notification
+    end
+
+    def case_id
+      @notification["caseId"]
+    end
+
+    def event_id
+      @notification["eventId"]
+    end
+
+    def formulaire_qf?
+      @notification["processCode"] == "FormulaireQF"
+    end
+
+    def id
+      @notification["id"]
+    end
+
+    def new_folder?
+      event_id.blank?
+    end
+  end
+end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -1,5 +1,5 @@
 class Shipment < ApplicationRecord
-  enum hubee_status: {pending: "pending", in_progress: "in_progress", done: "done", refused: "refused"}
+  enum hubee_status: {pending: "pending", sent: "sent", si_received: "si_received", in_progress: "in_progress", done: "done", refused: "refused"}
   validates :reference, presence: true, uniqueness: true, length: {is: 13}
   after_initialize :affect_reference
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,4 +65,5 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+  config.active_job.queue_adapter = :test
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -3,6 +3,7 @@ Rails.application.configure do
   config.good_job.enable_cron = ENV["FRONTAL"] == "true"
   config.good_job.cron = {
     populate_hubee_sandbox: {cron: "0 4 * * *", class: "PopulateHubEESandboxJob"},
+    process_hubee_notifications: {cron: "0 */4 * * *", class: "ReadHubEENotificationsJob"},
   }
 end
 

--- a/db/migrate/20240703094034_add_hubee_case_id_to_shipments.rb
+++ b/db/migrate/20240703094034_add_hubee_case_id_to_shipments.rb
@@ -1,0 +1,6 @@
+class AddHubEECaseIdToShipments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shipments, :hubee_case_id, :string
+    add_index :shipments, :hubee_case_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,8 +117,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_081757) do
     t.datetime "updated_at", null: false
     t.string "reference", null: false
     t.string "hubee_status", default: "pending"
+    t.string "hubee_case_id"
     t.bigint "collectivity_id", null: false
     t.index ["collectivity_id"], name: "index_shipments_on_collectivity_id"
+    t.index ["hubee_case_id"], name: "index_shipments_on_hubee_case_id"
     t.index ["hubee_status"], name: "index_shipments_on_hubee_status"
     t.index ["reference"], name: "index_shipments_on_reference", unique: true
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,7 @@
 # files.
 
 require "cucumber/rails"
+require "cucumber/rspec/doubles"
 
 # By default, any exception happening in your Rails application will bubble up
 # to Cucumber so that your scenario will fail. This is a different from how

--- a/lib/hubee/api.rb
+++ b/lib/hubee/api.rb
@@ -126,9 +126,9 @@ class HubEE::Api
     event
   end
 
-  def notifications(items: 50)
+  def notifications(items_count: 50)
     base_url = URI("#{Settings.hubee.base_url}/teledossiers/v1/notifications")
-    base_url.query = URI.encode_www_form(maxResult: items)
+    base_url.query = URI.encode_www_form(maxResult: items_count)
 
     https = Net::HTTP.new(base_url.host, base_url.port)
     https.use_ssl = true

--- a/lib/hubee/api.rb
+++ b/lib/hubee/api.rb
@@ -84,6 +84,64 @@ class HubEE::Api
     delete_response
   end
 
+  def delete_notification(notification_id:)
+    base_url = URI("#{Settings.hubee.base_url}/teledossiers/v1/notifications/#{notification_id}")
+
+    https = Net::HTTP.new(base_url.host, base_url.port)
+    https.use_ssl = true
+
+    request = Net::HTTP::Delete.new(base_url)
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = "Bearer #{access_token}"
+
+    # response = https.request(request)
+    # body = JSON.parse(response.body || "{}")
+    response = "DELETED"
+    Rails.logger.debug response
+    # Rails.logger.debug body
+
+    body
+  end
+
+  def event(id:, case_id:)
+    base_url = URI("#{Settings.hubee.base_url}/teledossiers/v1/cases/#{case_id}/events/#{id}")
+
+    https = Net::HTTP.new(base_url.host, base_url.port)
+    https.use_ssl = true
+
+    request = Net::HTTP::Get.new(base_url)
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = https.request(request)
+    event = JSON.parse(response.body || "{}")
+
+    Rails.logger.debug response.body
+    Rails.logger.debug event
+
+    event
+  end
+
+  def notifications
+    base_url = URI("#{Settings.hubee.base_url}/teledossiers/v1/notifications")
+    base_url.query = URI.encode_www_form(maxResult: 50)
+
+    https = Net::HTTP.new(base_url.host, base_url.port)
+    https.use_ssl = true
+
+    request = Net::HTTP::Get.new(base_url)
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = https.request(request)
+    notifications = JSON.parse(response.body || "{}")
+
+    Rails.logger.debug response.body
+    Rails.logger.debug notifications
+
+    notifications
+  end
+
   def upload_attachment(attachment:, folder_id:)
     base_url = URI("#{Settings.hubee.base_url}/teledossiers/v1/folders/#{folder_id}/attachments/#{attachment.id}")
     Rails.logger.debug base_url

--- a/spec/factories/hubee_case.rb
+++ b/spec/factories/hubee_case.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :hubee_case, class: HubEE::Case do
+    initialize_with { new(**attributes) }
+
+    external_id { "Formulaire-QF-ABCDEF1234567-01" }
+    recipient { build(:hubee_recipient) }
+
+    trait :with_id do
+      id { "case_uuid" }
+    end
+  end
+end

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
 
     hubee_folder_id { "folder_uuid" }
     hubee_status { :pending }
+    hubee_case_id { "case_uuid" }
   end
 end

--- a/spec/interactors/create_shipment_spec.rb
+++ b/spec/interactors/create_shipment_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CreateShipment, type: :interactor do
 
     let(:collectivity) { create(:collectivity) }
     let(:shipment) { Shipment.new(collectivity: collectivity) }
-    let(:folder) { instance_double("HubEE::Folder", id: "folder_uuid") }
+    let(:folder) { instance_double("HubEE::Folder", id: "folder_uuid", first_case_id: "case_uuid") }
     let(:params) do
       {
         folder:,

--- a/spec/interactors/prepare_quotient_familial_hubee_folder_spec.rb
+++ b/spec/interactors/prepare_quotient_familial_hubee_folder_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe PrepareQuotientFamilialHubEEFolder, type: :interactor do
         applicant: pivot_identity,
         attachments: [an_object_having_attributes(file_name: "FormulaireQF.json"), an_object_having_attributes(file_name: "FormulaireQF.xml"), an_object_having_attributes(file_name: "quotient_familial_Heinemeier_Hansson_David.pdf")],
         cases: [
-          external_id: "Formulaire-QF-ABCDEF1234567-01",
-          recipient:,
+          kase,
         ],
         external_id: "Formulaire-QF-ABCDEF1234567",
         process_code: "FormulaireQF",
       }
     end
     let(:recipient) { double(HubEE::Recipient) }
+    let(:kase) { build(:hubee_case, recipient:) }
     let(:pivot_identity) { PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male) }
     let(:quotient_familial) { FactoryBot.attributes_for(:quotient_familial_payload) }
     let(:collectivity) { create(:collectivity) }

--- a/spec/interactors/process_hubee_notification_spec.rb
+++ b/spec/interactors/process_hubee_notification_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe ProcessHubEENotification, type: :interactor do
+  subject(:interactor) { described_class.call(notification: notification_hash) }
+
+  let(:notification_hash) do
+    {
+      "caseId" => "1234",
+      "eventId" => "5678",
+      "processCode" => "FormulaireQF",
+      "id" => "abcd",
+    }
+  end
+
+  describe ".call" do
+    let(:event_payload) do
+      {
+        "actionType" => "STATUS_UPDATE",
+        "attachments" => [],
+        "author" => "John Doe",
+        "caseCurrentStatus" => "SENT",
+        "caseNewStatus" => status,
+        "comment" => "",
+        "createDateTime" => "2024-07-04T08:54:15.438+00:00",
+        "id" => "905055ea-ed37-4556-9db6-97ba89fcb91f",
+        "message" => "",
+        "notification" => true,
+        "partnerAttributes" => nil,
+        "partnerInfo" => {
+          "editorName" => "SOMEEDITOR",
+          "applicationName" => "Portail",
+          "softwareVersion" => "2.2.2",
+        },
+        "status" => "SENT",
+        "transmitter" => {
+          "type" => "SI",
+          "branchCode" => "04107",
+          "companyRegister" => "21040107100019",
+        },
+        "updateDateTime" => nil,
+      }
+    end
+    let(:session) { instance_double(HubEE::Api) }
+    let(:status) { "SI_RECEIVED" }
+
+    before do
+      allow(HubEE::Api).to receive(:session).and_return(session)
+      allow(session).to receive(:event).and_return(event_payload)
+      allow(session).to receive(:update_event)
+      allow(session).to receive(:delete_notification)
+    end
+
+    it "deletes the notification" do
+      expect(session).to receive(:delete_notification)
+      interactor
+    end
+
+    context "when the notification is for FormulaireQF" do
+      context "when the notification is for a new folder" do
+        context "when the event is valid, sent, and a status update" do
+          let!(:shipment) { create(:shipment, hubee_case_id: "1234") }
+
+          it "update the hubee event" do
+            expect(session).to receive(:update_event)
+            interactor
+          end
+
+          context "when the event is processable" do
+            it "updates the shipment status" do
+              expect { interactor }.to change { shipment.reload.hubee_status }.to("si_received")
+            end
+
+            context "when the event is a final status" do
+              let(:status) { "DONE" }
+
+              it "removes hubee ids" do
+                expect {
+                  interactor
+                  shipment.reload
+                }.to change { shipment.hubee_folder_id }.to(nil)
+                  .and change { shipment.hubee_case_id }.to(nil)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/interactors/process_hubee_notification_spec.rb
+++ b/spec/interactors/process_hubee_notification_spec.rb
@@ -54,10 +54,17 @@ RSpec.describe ProcessHubEENotification, type: :interactor do
       allow(session).to receive(:delete_notification)
     end
 
-    # it "deletes the notification" do
-    #   expect(session).to receive(:delete_notification)
-    #   interactor
-    # end
+    shared_examples "an ignored notification" do
+      it "deletes the notification" do
+        expect(session).to receive(:delete_notification)
+        interactor
+      end
+
+      it "does not update the event" do
+        expect(session).not_to receive(:update_event)
+        interactor
+      end
+    end
 
     context "when the notification is for FormulaireQF" do
       context "when the notification is for an existing folder" do
@@ -116,75 +123,35 @@ RSpec.describe ProcessHubEENotification, type: :interactor do
             context "when the event is not a status update" do
               let(:action_type) { "ATTACH_DEPOSIT" }
 
-              it "deletes the notification" do
-                expect(session).to receive(:delete_notification)
-                interactor
-              end
-
-              it "does not update the event" do
-                expect(session).not_to receive(:update_event)
-                interactor
-              end
+              it_behaves_like "an ignored notification"
             end
           end
 
           context "when the event is not sent" do
             let(:event_status) { "RECEIVED" }
 
-            it "deletes the notification" do
-              expect(session).to receive(:delete_notification)
-              interactor
-            end
-
-            it "does not update the event" do
-              expect(session).not_to receive(:update_event)
-              interactor
-            end
+            it_behaves_like "an ignored notification"
           end
         end
 
         context "when the event is not fetch correctly" do
           let(:event_payload) { {"errors" => ["some error"]} }
 
-          it "deletes the notification" do
-            expect(session).to receive(:delete_notification)
-            interactor
-          end
-
-          it "does not update the event" do
-            expect(session).not_to receive(:update_event)
-            interactor
-          end
+          it_behaves_like "an ignored notification"
         end
       end
 
       context "when the notification is for a new folder" do
         let(:event_id) { nil }
 
-        it "deletes the notification" do
-          expect(session).to receive(:delete_notification)
-          interactor
-        end
-
-        it "does not update the event" do
-          expect(session).not_to receive(:update_event)
-          interactor
-        end
+        it_behaves_like "an ignored notification"
       end
     end
 
     context "when the notification is not for FormulaireQF" do
       let(:process_code) { "CertDC" }
 
-      it "deletes the notification" do
-        expect(session).to receive(:delete_notification)
-        interactor
-      end
-
-      it "does not update the event" do
-        expect(session).not_to receive(:update_event)
-        interactor
-      end
+      it_behaves_like "an ignored notification"
     end
   end
 end

--- a/spec/jobs/read_hubee_notifications_job_spec.rb
+++ b/spec/jobs/read_hubee_notifications_job_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ReadHubEENotificationsJob, type: :job do
+  describe "#perform" do
+    subject(:job) { described_class.perform_now(items: 1) }
+
+    before do
+      stub_hubee_token
+      stub_hubee_notifications
+    end
+
+    it "processes the notifications" do
+      expect(ProcessHubEENotification).to receive(:call)
+      job
+    end
+
+    context "when there are potential remaining notifications" do
+      before do
+        allow(ProcessHubEENotification).to receive(:call)
+      end
+
+      it "enqueues another job" do
+        expect { job }.to have_enqueued_job(described_class)
+      end
+    end
+  end
+end

--- a/spec/jobs/read_hubee_notifications_job_spec.rb
+++ b/spec/jobs/read_hubee_notifications_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ReadHubEENotificationsJob, type: :job do
   describe "#perform" do
-    subject(:job) { described_class.perform_now(items: 1) }
+    subject(:job) { described_class.perform_now(items_count: 1) }
 
     before do
       stub_hubee_token

--- a/spec/lib/hubee/api_spec.rb
+++ b/spec/lib/hubee/api_spec.rb
@@ -158,5 +158,28 @@ RSpec.describe HubEE::Api, type: :api do
         end
       end
     end
+
+    describe "#notifications" do
+      subject(:notifications) { session.notifications }
+
+      before do
+        stub_hubee_notifications
+      end
+
+      let(:expected_response) do
+        array_including(
+          a_hash_including(
+            "caseId" => "3fa85f64-5717-4562-b3fc-2c963f66afa",
+            "eventId" => "3fa85f64-5717-4562-b3fc-2c963f66afa",
+            "processCode" => "FormulaireQF",
+            "id" => "3fa85f64-5717-4562-b3fc-2c963f66afa"
+          )
+        )
+      end
+
+      it "returns the notifications" do
+        expect(notifications).to match(expected_response)
+      end
+    end
   end
 end

--- a/spec/lib/hubee/api_spec.rb
+++ b/spec/lib/hubee/api_spec.rb
@@ -42,11 +42,12 @@ RSpec.describe HubEE::Api, type: :api do
       subject(:create_folder) { session.create_folder(folder: folder) }
 
       let(:attachments) { [json_attachment, xml_attachment, pdf_attachment] }
+      let(:cases) { [build(:hubee_case)] }
       let(:json_attachment) { build(:hubee_attachment, :with_file) }
       let(:xml_attachment) { build(:hubee_attachment, :with_file, file_name: "FormulaireQF.xml", mime_type: "application/xml", file_size: 1543) }
       let(:pdf_attachment) { build(:hubee_attachment, :with_file, file_name: "quotient_familial_Heinemeier_Hansson_David.pdf", mime_type: "application/pdf", file_size: 3079) }
 
-      let(:folder) { build(:hubee_folder, attachments: attachments) }
+      let(:folder) { build(:hubee_folder, attachments: attachments, cases: cases) }
 
       context "when the folder is succesfully created" do
         before do
@@ -71,6 +72,56 @@ RSpec.describe HubEE::Api, type: :api do
 
         it "deletes the folder" do
           expect(delete_folder).to have_attributes({})
+        end
+      end
+    end
+
+    describe "#delete_notification" do
+      subject(:delete_notification) { session.delete_notification(notification_id: notification_id) }
+
+      let(:notification_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+      context "when the notification is succesfully deleted" do
+        before do
+          stub_hubee_delete_notification
+        end
+
+        it "deletes the notification" do
+          expect(delete_notification).to have_attributes({})
+        end
+      end
+    end
+
+    describe "#event" do
+      subject(:event) { session.event(id:, case_id:) }
+
+      let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+      let(:case_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+      context "when the event is succesfully retrieved" do
+        before do
+          stub_hubee_event
+        end
+
+        it "retrieves the event" do
+          expect(event).to include("id" => "905055ea-ed37-4556-9db6-97ba89fcb91f")
+        end
+      end
+    end
+
+    describe "#update_event" do
+      subject(:update_event) { session.update_event(id:, case_id:) }
+
+      let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+      let(:case_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+      context "when the event is succesfully updated" do
+        before do
+          stub_hubee_update_event
+        end
+
+        it "updates the event" do
+          expect(update_event).to have_attributes({})
         end
       end
     end

--- a/spec/models/hubee/event_spec.rb
+++ b/spec/models/hubee/event_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe HubEE::Event, type: :model do
+  subject(:event) { described_class.new(event_hash) }
+
+  let(:event_hash) do
+    {
+      "actionType" => "STATUS_UPDATE",
+      "attachments" => [],
+      "author" => "John Doe",
+      "caseCurrentStatus" => "SENT",
+      "caseNewStatus" => "SI_RECEIVED",
+      "comment" => "",
+      "createDateTime" => "2024-07-04T08:54:15.438+00:00",
+      "id" => "905055ea-ed37-4556-9db6-97ba89fcb91f",
+      "message" => "",
+      "notification" => true,
+      "partnerAttributes" => nil,
+      "partnerInfo" => {
+        "editorName" => "SOMEEDITOR",
+        "applicationName" => "Portail",
+        "softwareVersion" => "2.2.2",
+      },
+      "status" => "SENT",
+      "transmitter" => {
+        "type" => "SI",
+        "branchCode" => "04107",
+        "companyRegister" => "21040107100019",
+      },
+      "updateDateTime" => nil,
+    }
+  end
+
+  describe "#case_current_status" do
+    it "returns the case current status" do
+      expect(event.case_current_status).to eq("SENT")
+    end
+  end
+
+  describe "#case_new_status" do
+    it "returns the case new status" do
+      expect(event.case_new_status).to eq("SI_RECEIVED")
+    end
+  end
+
+  describe "#final_status?" do
+    context "when the case new status is final" do
+      let(:event_hash) do
+        {"caseNewStatus" => "DONE"}
+      end
+
+      it "returns true" do
+        expect(event.final_status?).to be true
+      end
+    end
+
+    context "when the case new status is not final" do
+      let(:event_hash) do
+        {"caseNewStatus" => "SENT"}
+      end
+
+      it "returns false" do
+        expect(event.final_status?).to be false
+      end
+    end
+  end
+
+  describe "#processable?" do
+    context "when the event is processable" do
+      let(:event_hash) do
+        {"caseNewStatus" => "SENT"}
+      end
+
+      it "returns true" do
+        expect(event.processable?).to be true
+      end
+    end
+
+    context "when the event is not processable" do
+      let(:event_hash) do
+        {"caseNewStatus" => "RECEIVED"}
+      end
+
+      it "returns false" do
+        expect(event.processable?).to be false
+      end
+    end
+  end
+
+  describe "#received?" do
+    context "when the event status is received" do
+      let(:event_hash) do
+        {"status" => "RECEIVED"}
+      end
+
+      it "returns true" do
+        expect(event.received?).to be true
+      end
+    end
+
+    context "when the event status is not received" do
+      let(:event_hash) do
+        {"status" => "SENT"}
+      end
+
+      it "returns false" do
+        expect(event.received?).to be false
+      end
+    end
+  end
+
+  describe "#sent?" do
+    context "when the event status is sent" do
+      let(:event_hash) do
+        {"status" => "SENT"}
+      end
+
+      it "returns true" do
+        expect(event.sent?).to be true
+      end
+    end
+
+    context "when the event status is not sent" do
+      let(:event_hash) do
+        {"status" => "RECEIVED"}
+      end
+
+      it "returns false" do
+        expect(event.sent?).to be false
+      end
+    end
+  end
+
+  describe "#status" do
+    it "returns the status" do
+      expect(event.status).to eq("SENT")
+    end
+  end
+
+  describe "#status_update?" do
+    context "when the action type is status update" do
+      let(:event_hash) do
+        {"actionType" => "STATUS_UPDATE"}
+      end
+
+      it "returns true" do
+        expect(event.status_update?).to be true
+      end
+    end
+
+    context "when the action type is not status update" do
+      let(:event_hash) do
+        {"actionType" => "ATTACH_DEPOSIT"}
+      end
+
+      it "returns false" do
+        expect(event.status_update?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/hubee/event_spec.rb
+++ b/spec/models/hubee/event_spec.rb
@@ -31,15 +31,31 @@ RSpec.describe HubEE::Event, type: :model do
     }
   end
 
-  describe "#case_current_status" do
-    it "returns the case current status" do
-      expect(event.case_current_status).to eq("SENT")
-    end
-  end
-
   describe "#case_new_status" do
     it "returns the case new status" do
       expect(event.case_new_status).to eq("SI_RECEIVED")
+    end
+  end
+
+  describe "#error?" do
+    context "when the event status is error" do
+      let(:event_hash) do
+        {"errors" => "ERROR"}
+      end
+
+      it "returns true" do
+        expect(event.error?).to be true
+      end
+    end
+
+    context "when the event status is not error" do
+      let(:event_hash) do
+        {}
+      end
+
+      it "returns false" do
+        expect(event.error?).to be false
+      end
     end
   end
 
@@ -83,28 +99,6 @@ RSpec.describe HubEE::Event, type: :model do
 
       it "returns false" do
         expect(event.processable?).to be false
-      end
-    end
-  end
-
-  describe "#received?" do
-    context "when the event status is received" do
-      let(:event_hash) do
-        {"status" => "RECEIVED"}
-      end
-
-      it "returns true" do
-        expect(event.received?).to be true
-      end
-    end
-
-    context "when the event status is not received" do
-      let(:event_hash) do
-        {"status" => "SENT"}
-      end
-
-      it "returns false" do
-        expect(event.received?).to be false
       end
     end
   end

--- a/spec/models/hubee/notification_spec.rb
+++ b/spec/models/hubee/notification_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe HubEE::Notification, type: :model do
+  subject(:notification) { described_class.new(notification_hash) }
+
+  let(:notification_hash) do
+    {
+      "caseId" => "1234",
+      "eventId" => "5678",
+      "processCode" => "FormulaireQF",
+      "id" => "abcd",
+    }
+  end
+
+  describe "#case_id" do
+    it "returns the case id" do
+      expect(notification.case_id).to eq("1234")
+    end
+  end
+
+  describe "#event_id" do
+    it "returns the event id" do
+      expect(notification.event_id).to eq("5678")
+    end
+  end
+
+  describe "#formulaire_qf?" do
+    context "when the process code is FormulaireQF" do
+      it "returns true" do
+        expect(notification.formulaire_qf?).to be true
+      end
+    end
+
+    context "when the process code is not FormulaireQF" do
+      let(:notification_hash) do
+        {"processCode" => "Other"}
+      end
+
+      it "returns false" do
+        expect(notification.formulaire_qf?).to be false
+      end
+    end
+  end
+
+  describe "#id" do
+    it "returns the id" do
+      expect(notification.id).to eq("abcd")
+    end
+  end
+
+  describe "#new_folder?" do
+    context "when the event id is blank" do
+      let(:notification_hash) do
+        {"eventId" => ""}
+      end
+
+      it "returns true" do
+        expect(notification.new_folder?).to be true
+      end
+    end
+
+    context "when the event id is not blank" do
+      it "returns false" do
+        expect(notification.new_folder?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Shipment, type: :model do
     it { is_expected.to validate_length_of(:reference).is_equal_to(13) }
   end
 
-  it { is_expected.to define_enum_for(:hubee_status).with_values(pending: "pending", in_progress: "in_progress", done: "done", refused: "refused").backed_by_column_of_type(:string) }
+  it { is_expected.to define_enum_for(:hubee_status).with_values(pending: "pending", sent: "sent", si_received: "si_received", in_progress: "in_progress", done: "done", refused: "refused").backed_by_column_of_type(:string) }
 
   describe "assign_reference" do
     subject { described_class.new }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "matchers/organizer"
+RSpec::Matchers.define_negated_matcher :not_change, :change
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/provider_stubs/hubee.rb
+++ b/spec/support/provider_stubs/hubee.rb
@@ -80,6 +80,8 @@ module ProviderStubs::HubEE
   end
 
   def stub_hubee_create_folder(names: "Heinemeier_Hansson_David")
+    SecureRandom.stub(:hex).and_return("abcdef1234567thiswontbeused")
+
     stub_request(:post, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/folders")
       .to_return(status: 200, body:  {
         id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
@@ -143,6 +145,62 @@ module ProviderStubs::HubEE
           },
         ],
       }.to_json, headers: {})
+  end
+
+  def stub_hubee_notifications
+    notifications = [
+      {
+        "id" => "3fa85f64-5717-4562-b3fc-2c963f66afa",
+        "caseId" => "3fa85f64-5717-4562-b3fc-2c963f66afa",
+        "eventId" => "3fa85f64-5717-4562-b3fc-2c963f66afa",
+        "processCode" => "FormulaireQF",
+      },
+    ]
+
+    stub_request(:get, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/notifications")
+      .with(query: hash_including("maxResult"))
+      .to_return(status: 200, body: notifications.to_json)
+  end
+
+  def stub_hubee_delete_notification
+    stub_request(:delete, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/notifications/3fa85f64-5717-4562-b3fc-2c963f66afa6")
+      .to_return(status: 204, body: "", headers: {})
+  end
+
+  def stub_hubee_event
+    payload = {
+      "actionType" => "STATUS_UPDATE",
+      "attachments" => [],
+      "author" => "John Doe",
+      "caseCurrentStatus" => "SENT",
+      "caseNewStatus" => "SI_RECEIVED",
+      "comment" => "",
+      "createDateTime" => "2024-07-04T08:54:15.438+00:00",
+      "id" => "905055ea-ed37-4556-9db6-97ba89fcb91f",
+      "message" => "",
+      "notification" => true,
+      "partnerAttributes" => nil,
+      "partnerInfo" => {
+        "editorName" => "SOMEEDITOR",
+        "applicationName" => "Portail",
+        "softwareVersion" => "2.2.2",
+      },
+      "status" => "SENT",
+      "transmitter" => {
+        "type" => "SI",
+        "branchCode" => "04107",
+        "companyRegister" => "21040107100019",
+      },
+      "updateDateTime" => nil,
+    }
+
+    stub_request(:get, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/cases/3fa85f64-5717-4562-b3fc-2c963f66afa6/events/3fa85f64-5717-4562-b3fc-2c963f66afa6")
+      .to_return(status: 200, body: payload.to_json, headers: {})
+  end
+
+  def stub_hubee_update_event
+    stub_request(:patch, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/cases/3fa85f64-5717-4562-b3fc-2c963f66afa6/events/3fa85f64-5717-4562-b3fc-2c963f66afa6")
+      .to_return(status: 204, body: "", headers: {})
   end
 
   def stub_hubee_upload_attachment


### PR DESCRIPTION
Cette PR utilise le système de cron de good_job pour lancer un job de traitement des notifications HubEE toutes les 4 heures.

Ce job met à jour les shipments (quand ils existent) ainsi que les event/cases/notifications côté HubEE.
Il se relance lui même tant que toutes les notifications n'ont pas été traitées.

Il reste à faire en follow-up :
- Clôturer les case/folder HuBEE quand le statut est final