### PR TITLE
harden display of QF date if either the year or the month is empty

### DIFF
--- a/app/facades/quotient_familial_facade.rb
+++ b/app/facades/quotient_familial_facade.rb
@@ -45,9 +45,7 @@ class QuotientFamilialFacade
   private
 
   def month_year_is_invalid
-    quotient_familial["mois"].blank? ||
-      quotient_familial["mois"].to_i.zero? ||
-      quotient_familial["annee"].blank? ||
+    quotient_familial["mois"].to_i.zero? ||
       quotient_familial["annee"].to_i.zero?
   end
 

--- a/app/facades/quotient_familial_facade.rb
+++ b/app/facades/quotient_familial_facade.rb
@@ -19,8 +19,13 @@ class QuotientFamilialFacade
 
   def month_year
     return nil if empty?
-    month_number = quotient_familial["mois"] || Time.zone.today.strftime("%m").to_i
-    year_number = quotient_familial["annee"] || Time.zone.today.strftime("%Y")
+    if quotient_familial["mois"].blank? || quotient_familial["annee"].blank?
+      month_number = Time.zone.today.strftime("%m").to_i
+      year_number = Time.zone.today.strftime("%Y")
+    else
+      month_number = quotient_familial["mois"]
+      year_number = quotient_familial["annee"]
+    end
     month = I18n.t("date.month_names")[month_number]
     "#{month} #{year_number}"
   end

--- a/app/facades/quotient_familial_facade.rb
+++ b/app/facades/quotient_familial_facade.rb
@@ -19,13 +19,15 @@ class QuotientFamilialFacade
 
   def month_year
     return nil if empty?
-    if quotient_familial["mois"].blank? || quotient_familial["annee"].blank?
+
+    if month_year_is_invalid
       month_number = Time.zone.today.strftime("%m").to_i
       year_number = Time.zone.today.strftime("%Y")
     else
-      month_number = quotient_familial["mois"]
+      month_number = quotient_familial["mois"].to_i
       year_number = quotient_familial["annee"]
     end
+
     month = I18n.t("date.month_names")[month_number]
     "#{month} #{year_number}"
   end
@@ -41,6 +43,13 @@ class QuotientFamilialFacade
   end
 
   private
+
+  def month_year_is_invalid
+    quotient_familial["mois"].blank? ||
+      quotient_familial["mois"].to_i.zero? ||
+      quotient_familial["annee"].blank? ||
+      quotient_familial["annee"].to_i.zero?
+  end
 
   def person_facade(person)
     nom_usage = if person["nomUsage"] && person["nomUsage"] != person["nomNaissance"]

--- a/spec/facades/quotient_familial_facade_spec.rb
+++ b/spec/facades/quotient_familial_facade_spec.rb
@@ -52,19 +52,39 @@ RSpec.describe QuotientFamilialFacade do
       end
     end
 
-    context "when there is a missing month and year" do
-      let(:quotient_familial) { {"quotientFamilial" => 12, "annee" => nil, "mois" => nil} }
+    context "when we don't have correct year/month data" do
+      let(:quotient_familial) { {"quotientFamilial" => 12, "annee" => year, "mois" => month} }
+      let(:year) { 2024 }
+      let(:month) { 6 }
 
-      it "uses the current month and year" do
-        expect(subject.month_year).to eq "février 1990"
+      shared_examples "it uses the current month and year" do
+        it "uses the current month and year" do
+          expect(subject.month_year).to eq "février 1990"
+        end
       end
-    end
 
-    context "when there is a missing month or year" do
-      let(:quotient_familial) { {"quotientFamilial" => 12, "annee" => 2024, "mois" => nil} }
+      context "when there is a missing month" do
+        let(:month) { nil }
 
-      it "uses the current month and year" do
-        expect(subject.month_year).to eq "février 1990"
+        include_examples "it uses the current month and year"
+      end
+
+      context "when the month is zero" do
+        let(:month) { 0 }
+
+        include_examples "it uses the current month and year"
+      end
+
+      context "when there is a missing year" do
+        let(:year) { nil }
+
+        include_examples "it uses the current month and year"
+      end
+
+      context "when the year is zero" do
+        let(:year) { 0 }
+
+        include_examples "it uses the current month and year"
       end
     end
   end

--- a/spec/facades/quotient_familial_facade_spec.rb
+++ b/spec/facades/quotient_familial_facade_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe QuotientFamilialFacade do
         expect(subject.month_year).to eq "février 1990"
       end
     end
+
+    context "when there is a missing month or year" do
+      let(:quotient_familial) { {"quotientFamilial" => 12, "annee" => 2024, "mois" => nil} }
+
+      it "uses the current month and year" do
+        expect(subject.month_year).to eq "février 1990"
+      end
+    end
   end
 
   describe "#allocataires" do


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-3133/affichage-sans-fournisseur-de-donnee