### PR TITLE
Clôture les dossiers HubEE sur réception d'un statut final

### DIFF
--- a/app/models/hubee/event.rb
+++ b/app/models/hubee/event.rb
@@ -7,6 +7,10 @@ module HubEE
       @event = event
     end
 
+    def case_current_status
+      @event["caseCurrentStatus"]
+    end
+
     def case_new_status
       @event["caseNewStatus"]
     end

--- a/lib/hubee/api.rb
+++ b/lib/hubee/api.rb
@@ -9,7 +9,34 @@ class HubEE::Api
 
   def active_subscriptions
     url = "#{Settings.hubee.base_url}/referential/v1/subscriptions"
+
     get(url, query_params: {maxResult: 5000, status: "Actif", processCode: "FormulaireQF"})
+  end
+
+  def close_case(case_id:)
+    url = "#{Settings.hubee.base_url}/teledossiers/v1/cases/#{case_id}"
+
+    patch(url, body: {"status" => "CLOSED"})
+  end
+
+  def close_folder(folder_id:)
+    url = "#{Settings.hubee.base_url}/teledossiers/v1/folders/#{folder_id}"
+
+    patch(url, body: {"globalStatus" => "CLOSED"})
+  end
+
+  def create_event(case_id:, current_status:, new_status:)
+    url = "#{Settings.hubee.base_url}/teledossiers/v1/cases/#{case_id}/events"
+    body = {
+      "message" => "Dossier traité par le service.",
+      "actionType" => "STATUS_UPDATE",
+      "author" => "DINUM",
+      "notification" => true,
+      "caseCurrentStatus" => current_status,
+      "caseNewStatus" => new_status,
+    }
+
+    post(url, body:)
   end
 
   def create_folder(folder:)

--- a/spec/interactors/process_hubee_notification_spec.rb
+++ b/spec/interactors/process_hubee_notification_spec.rb
@@ -92,12 +92,25 @@ RSpec.describe ProcessHubEENotification, type: :interactor do
                 context "when the event is a final status" do
                   let(:status) { "DONE" }
 
+                  before do
+                    allow(session).to receive(:close_case)
+                    allow(session).to receive(:create_event)
+                    allow(session).to receive(:close_folder)
+                  end
+
                   it "removes hubee ids" do
                     expect {
                       interactor
                       shipment.reload
                     }.to change { shipment.hubee_folder_id }.to(nil)
                       .and change { shipment.hubee_case_id }.to(nil)
+                  end
+
+                  it "closes the folder" do
+                    expect(session).to receive(:close_case)
+                    expect(session).to receive(:create_event)
+                    expect(session).to receive(:close_folder)
+                    interactor
                   end
                 end
 

--- a/spec/lib/hubee/api_spec.rb
+++ b/spec/lib/hubee/api_spec.rb
@@ -40,6 +40,62 @@ RSpec.describe HubEE::Api, type: :api do
       end
     end
 
+    describe "#close_case" do
+      subject(:response) { session.close_case(case_id:) }
+
+      let(:case_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+      context "when the case is succesfully closed" do
+        before do
+          stub_hubee_close_case
+        end
+
+        it { is_expected.to be_a_success }
+
+        it "closes the case" do
+          expect(response.code).to eq(204)
+        end
+      end
+    end
+
+    describe "#close_folder" do
+      subject(:response) { session.close_folder(folder_id:) }
+
+      let(:folder_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+      context "when the folder is succesfully closed" do
+        before do
+          stub_hubee_close_folder
+        end
+
+        it { is_expected.to be_a_success }
+
+        it "closes the folder" do
+          expect(response.code).to eq(204)
+        end
+      end
+    end
+
+    describe "#create_event" do
+      subject(:response) { session.create_event(case_id:, current_status:, new_status:) }
+
+      let(:case_id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+      let(:current_status) { "IN_PROGRESS" }
+      let(:new_status) { "CLOSED" }
+
+      context "when the event is succesfully created" do
+        before do
+          stub_hubee_create_event
+        end
+
+        it { is_expected.to be_a_success }
+
+        it "creates the event" do
+          expect(response.code).to eq(201)
+        end
+      end
+    end
+
     describe "#create_folder" do
       subject(:response) { session.create_folder(folder: folder) }
 

--- a/spec/models/hubee/event_spec.rb
+++ b/spec/models/hubee/event_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe HubEE::Event, type: :model do
     }
   end
 
+  describe "#case_current_status" do
+    it "returns the case current status" do
+      expect(event.case_current_status).to eq("SENT")
+    end
+  end
+
   describe "#case_new_status" do
     it "returns the case new status" do
       expect(event.case_new_status).to eq("SI_RECEIVED")

--- a/spec/support/provider_stubs/hubee.rb
+++ b/spec/support/provider_stubs/hubee.rb
@@ -79,6 +79,21 @@ module ProviderStubs::HubEE
       )
   end
 
+  def stub_hubee_close_case
+    stub_request(:patch, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/cases/3fa85f64-5717-4562-b3fc-2c963f66afa6")
+      .to_return(status: 204, body: "", headers: {})
+  end
+
+  def stub_hubee_close_folder
+    stub_request(:patch, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/folders/3fa85f64-5717-4562-b3fc-2c963f66afa6")
+      .to_return(status: 204, body: "", headers: {})
+  end
+
+  def stub_hubee_create_event
+    stub_request(:post, "https://api.bas.hubee.numerique.gouv.fr/teledossiers/v1/cases/3fa85f64-5717-4562-b3fc-2c963f66afa6/events")
+      .to_return(status: 201, body: "", headers: {})
+  end
+
   def stub_hubee_create_folder(names: "Heinemeier_Hansson_David")
     allow(SecureRandom).to receive(:hex).and_return("abcdef1234567thiswontbeused")
 


### PR DESCRIPTION
Cette PR clôture les télédossiers HubEE lors de la récupération d'une notification finale (statut "done" ou "refused").