### PR TITLE
Fixe une erreur lorsque l'identité pivot n'a pas de date de naissance

### DIFF
--- a/app/models/pivot_identity.rb
+++ b/app/models/pivot_identity.rb
@@ -1,5 +1,17 @@
 class PivotIdentity
-  attr_reader :birth_country, :birthdate, :birthplace, :first_names, :gender, :last_name
+  attr_reader :birth_country, :birthplace, :first_names, :gender, :last_name
+
+  class NilBirthdate
+    def year = nil
+
+    def month = nil
+
+    def day = nil
+
+    def strftime(*) = ""
+
+    def blank? = true
+  end
 
   def initialize(birth_country: nil, birthdate: nil, birthplace: nil, first_names: [], gender: nil, last_name: nil)
     @birth_country = birth_country
@@ -12,6 +24,12 @@ class PivotIdentity
 
   def [](key)
     public_send(key)
+  end
+
+  def birthdate
+    return @birthdate if @birthdate
+
+    NilBirthdate.new
   end
 
   def first_name

--- a/spec/models/pivot_identity_spec.rb
+++ b/spec/models/pivot_identity_spec.rb
@@ -10,6 +10,24 @@ describe PivotIdentity, type: :model do
     it { is_expected.to respond_to(:last_name) }
   end
 
+  describe "birthdate" do
+    subject(:birthdate) { pivot_identity.birthdate }
+
+    context "when birthdate is nil" do
+      let(:pivot_identity) { build(:pivot_identity, birthdate: nil) }
+
+      it { is_expected.to be_a(PivotIdentity::NilBirthdate) }
+
+      it { is_expected.to have_attributes(year: nil, month: nil, day: nil, strftime: "", blank?: true) }
+    end
+
+    context "when birthdate is not nil" do
+      let(:pivot_identity) { build(:pivot_identity, birthdate: Date.new(1989, 10, 2)) }
+
+      it { is_expected.to eq(Date.new(1989, 10, 2)) }
+    end
+  end
+
   describe "#first_name" do
     subject(:first_name) { pivot_identity.first_name }
 


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-3265/fix-erreur-date-de-naissance-non-remplie-sur-lidentite-pivot