### PR TITLE
Met en place le retry sur le job de lecture de notifications hubee

### DIFF
--- a/app/jobs/read_hubee_notifications_job.rb
+++ b/app/jobs/read_hubee_notifications_job.rb
@@ -1,6 +1,8 @@
 class ReadHubEENotificationsJob < ApplicationJob
   queue_as :default
 
+  retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 8
+
   def perform(items_count: 100)
     notifications = HubEE::Api.session.notifications(items_count:).body
     notifications.each do |notification|


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-3267/fix-erreur-retry-les-jobs-de-lecture-de-notifications-hubee