### PR TITLE
valdiates presence on shipment's hubee columns

### DIFF
--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -1,6 +1,7 @@
 class Shipment < ApplicationRecord
   enum :hubee_status, {pending: "pending", sent: "sent", si_received: "si_received", in_progress: "in_progress", done: "done", refused: "refused"}
   validates :reference, presence: true, uniqueness: true, length: {is: 13}
+  validates_presence_of :hubee_case_id, :hubee_folder_id
   after_initialize :affect_reference
 
   belongs_to :collectivity

--- a/db/migrate/20240827093608_add_validations_on_shipments_hubee_columns.rb
+++ b/db/migrate/20240827093608_add_validations_on_shipments_hubee_columns.rb
@@ -1,0 +1,7 @@
+class AddValidationsOnShipmentsHubEEColumns < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :shipments, :hubee_case_id
+    add_index :shipments, :hubee_case_id, unique: true
+    add_index :shipments, :hubee_folder_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_162842) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_27_093608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -129,7 +129,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_162842) do
     t.bigint "collectivity_id", null: false
     t.string "hubee_case_id"
     t.index ["collectivity_id"], name: "index_shipments_on_collectivity_id"
-    t.index ["hubee_case_id"], name: "index_shipments_on_hubee_case_id"
+    t.index ["hubee_case_id"], name: "index_shipments_on_hubee_case_id", unique: true
+    t.index ["hubee_folder_id"], name: "index_shipments_on_hubee_folder_id", unique: true
     t.index ["hubee_status"], name: "index_shipments_on_hubee_status"
     t.index ["reference"], name: "index_shipments_on_reference", unique: true
   end

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Shipment, type: :model do
 
     it { is_expected.to belong_to(:collectivity) }
     it { is_expected.to validate_presence_of(:reference) }
+    it { is_expected.to validate_presence_of(:hubee_case_id) }
+    it { is_expected.to validate_presence_of(:hubee_folder_id) }
     it { is_expected.to validate_uniqueness_of(:reference) }
     it { is_expected.to validate_length_of(:reference).is_equal_to(13) }
   end


### PR DESCRIPTION
Des shipments en prod n'ont pas les colonnes hubee remplies, c'est un problème.
J'ajoute ces validations pour qu'on ait des erreurs qui pop dans ce cas, et qu'on ait pas l'impression que tout va bien.