### PR TITLE
Send original pivot identity

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -19,6 +19,7 @@ class ShipmentsController < ApplicationController
       collectivity: @collectivity,
       external_id: Current.external_id,
       pivot_identity: Current.pivot_identity,
+      original_pivot_identity: Current.original_pivot_identity,
       quotient_familial: Current.quotient_familial,
       user: Current.user
     )

--- a/app/interactors/prepare_quotient_familial_hubee_folder.rb
+++ b/app/interactors/prepare_quotient_familial_hubee_folder.rb
@@ -66,7 +66,12 @@ class PrepareQuotientFamilialHubEEFolder < BaseInteractor
   end
 
   def shipment_data
-    ShipmentData.new(external_id: context.external_id, pivot_identity: context.pivot_identity, quotient_familial: context.quotient_familial)
+    ShipmentData.new(
+      external_id: context.external_id,
+      pivot_identity: context.pivot_identity,
+      original_pivot_identity: context.original_pivot_identity,
+      quotient_familial: context.quotient_familial
+    )
   end
 
   def xml_file

--- a/app/interactors/setup_current_data.rb
+++ b/app/interactors/setup_current_data.rb
@@ -24,7 +24,7 @@ class SetupCurrentData < BaseInteractor
   end
 
   def original_pivot_identity
-    session_raw_info.slice('birthcountry', 'birthdate', 'birthplace', 'family_name', 'given_name', 'gender')
+    session_raw_info.slice("birthcountry", "birthdate", "birthplace", "family_name", "given_name", "gender")
   end
 
   def quotient_familial

--- a/app/interactors/setup_current_data.rb
+++ b/app/interactors/setup_current_data.rb
@@ -1,6 +1,7 @@
 class SetupCurrentData < BaseInteractor
   def call
     Current.pivot_identity = pivot_identity
+    Current.original_pivot_identity = original_pivot_identity
     Current.quotient_familial = quotient_familial
     Current.collectivity = collectivity
     Current.user = user
@@ -20,6 +21,10 @@ class SetupCurrentData < BaseInteractor
 
   def pivot_identity
     PivotIdentity.new(**FranceConnect::IdentityMapper.normalize(session_raw_info))
+  end
+
+  def original_pivot_identity
+    session_raw_info.slice('birthcountry', 'birthdate', 'birthplace', 'family_name', 'given_name', 'gender')
   end
 
   def quotient_familial

--- a/app/jobs/populate_hubee_sandbox_job.rb
+++ b/app/jobs/populate_hubee_sandbox_job.rb
@@ -12,7 +12,12 @@ class PopulateHubEESandboxJob < ApplicationJob
       Rails.logger.debug { "### Adding data to #{name} ###" }
 
       collectivity = Collectivity.find_or_initialize_by(siret:, code_cog:, name:, status: :active)
-      result = UploadQuotientFamilialToHubEE.call(collectivity: collectivity, pivot_identity: pivot_identity, quotient_familial: quotient_familial)
+      result = UploadQuotientFamilialToHubEE.call(
+        collectivity:,
+        pivot_identity:,
+        original_pivot_identity:,
+        quotient_familial:
+      )
 
       if result.success?
         Rails.logger.debug { "   >>> Data added to #{name}, id: #{result.folder.id} ###" }
@@ -26,6 +31,17 @@ class PopulateHubEESandboxJob < ApplicationJob
 
   def pivot_identity
     PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male)
+  end
+
+  def original_pivot_identity
+    {
+      family_name: "Heinemeier Hansson",
+      given_name: "David",
+      gender: "male",
+      birthdate: "1979-10-15",
+      birthplace: nil,
+      birthcountry: "99135",
+    }
   end
 
   def quotient_familial

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,9 +1,9 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :pivot_identity,
-            :original_pivot_identity,
-            :quotient_familial,
-            :collectivity,
-            :user,
-            :external_id,
-            :redirect_uri
+    :original_pivot_identity,
+    :quotient_familial,
+    :collectivity,
+    :user,
+    :external_id,
+    :redirect_uri
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,9 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :pivot_identity, :quotient_familial, :collectivity, :user, :external_id, :redirect_uri
+  attribute :pivot_identity,
+            :original_pivot_identity,
+            :quotient_familial,
+            :collectivity,
+            :user,
+            :external_id,
+            :redirect_uri
 end

--- a/app/models/shipment_data.rb
+++ b/app/models/shipment_data.rb
@@ -1,9 +1,10 @@
 class ShipmentData
-  attr_reader :external_id, :pivot_identity, :quotient_familial
+  attr_reader :external_id, :pivot_identity, :original_pivot_identity, :quotient_familial
 
-  def initialize(pivot_identity:, quotient_familial:, external_id: nil)
+  def initialize(pivot_identity:, original_pivot_identity:, quotient_familial:, external_id: nil)
     @external_id = external_id
     @pivot_identity = pivot_identity
+    @original_pivot_identity = original_pivot_identity
     @quotient_familial = quotient_familial.with_indifferent_access
   end
 
@@ -19,6 +20,7 @@ class ShipmentData
         prenoms: pivot_identity.first_names,
         sexe: (pivot_identity.gender == :female) ? "F" : "M",
         nomUsuel: pivot_identity.last_name,
+        **original_pivot_identity,
       },
       quotient_familial:,
     }

--- a/spec/factories/france_connect_payload.rb
+++ b/spec/factories/france_connect_payload.rb
@@ -1,13 +1,16 @@
 FactoryBot.define do
-  factory :france_connect_payload, class: Hash do
+  factory :original_pivot_identity, class: Hash do
     initialize_with { attributes.deep_stringify_keys }
 
-    sub { "some_sub" }
     family_name { "TESTMAN" }
     given_name { "Johnny Paul René" }
     gender { "male" }
     birthdate { "1989-10-08" }
     birthplace { "75107" }
     birthcountry { "99100" }
+
+    factory :france_connect_payload, class: Hash do
+      sub { "some_sub" }
+    end
   end
 end

--- a/spec/interactors/prepare_quotient_familial_hubee_folder_spec.rb
+++ b/spec/interactors/prepare_quotient_familial_hubee_folder_spec.rb
@@ -16,11 +16,13 @@ RSpec.describe PrepareQuotientFamilialHubEEFolder, type: :interactor do
     let(:recipient) { double(HubEE::Recipient) }
     let(:kase) { build(:hubee_case, recipient:) }
     let(:pivot_identity) { PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male) }
+    let(:original_pivot_identity) { build(:original_pivot_identity) }
     let(:quotient_familial) { FactoryBot.build(:quotient_familial_v2_payload) }
     let(:collectivity) { create(:collectivity) }
     let(:params) do
       {
         pivot_identity:,
+        original_pivot_identity:,
         quotient_familial:,
         collectivity:,
       }

--- a/spec/interactors/setup_current_data_spec.rb
+++ b/spec/interactors/setup_current_data_spec.rb
@@ -46,11 +46,10 @@ describe SetupCurrentData, type: :interactor do
 
     context "with a session from FranceConnect" do
       let(:france_connect_payload) { build(:france_connect_payload) }
-      let(:session) { { "raw_info" => france_connect_payload } }
-
+      let(:session) { {"raw_info" => france_connect_payload} }
 
       it "sets up the current original pivot identity" do
-        expect { call }.to change { Current.original_pivot_identity }.from(nil).to(france_connect_payload.except('sub'))
+        expect { call }.to change { Current.original_pivot_identity }.from(nil).to(france_connect_payload.except("sub"))
       end
     end
   end

--- a/spec/interactors/setup_current_data_spec.rb
+++ b/spec/interactors/setup_current_data_spec.rb
@@ -9,6 +9,7 @@ describe SetupCurrentData, type: :interactor do
     before do
       Current.user = nil
       Current.pivot_identity = nil
+      Current.original_pivot_identity = nil
       Current.quotient_familial = nil
       Current.collectivity = nil
       Current.external_id = nil
@@ -21,10 +22,6 @@ describe SetupCurrentData, type: :interactor do
 
     it "sets up the current user" do
       expect { call }.to change { Current.user }.from(nil).to(instance_of(User))
-    end
-
-    it "sets up the current pivot identity" do
-      expect { call }.to change { Current.pivot_identity }.from(nil).to(instance_of(PivotIdentity))
     end
 
     it "sets up the current quotient familial" do
@@ -41,6 +38,20 @@ describe SetupCurrentData, type: :interactor do
 
     it "sets up the current redirect uri" do
       expect { call }.to change { Current.redirect_uri }.from(nil).to("https://real_uri")
+    end
+
+    it "sets up the current pivot identity" do
+      expect { call }.to change { Current.pivot_identity }.from(nil).to(instance_of(PivotIdentity))
+    end
+
+    context "with a session from FranceConnect" do
+      let(:france_connect_payload) { build(:france_connect_payload) }
+      let(:session) { { "raw_info" => france_connect_payload } }
+
+
+      it "sets up the current original pivot identity" do
+        expect { call }.to change { Current.original_pivot_identity }.from(nil).to(france_connect_payload.except('sub'))
+      end
     end
   end
 end

--- a/spec/models/shipment_data_spec.rb
+++ b/spec/models/shipment_data_spec.rb
@@ -1,124 +1,61 @@
 RSpec.describe ShipmentData, type: :model do
-  subject(:shipment_data) { described_class.new(external_id:, pivot_identity:, quotient_familial:) }
+  subject(:shipment_data) { described_class.new(external_id:, pivot_identity:, original_pivot_identity:, quotient_familial:) }
 
   let(:external_id) { "external_id" }
   let(:pivot_identity) { PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male) }
+  let(:original_pivot_identity) { build(:original_pivot_identity) }
   let(:quotient_familial) { FactoryBot.build(:quotient_familial_v2_payload) }
+  let(:expected_hash) do
+    {
+      external_id: "external_id",
+      pivot_identity: {
+        codePaysLieuDeNaissance: "99135",
+        anneeDateDeNaissance: 1979,
+        moisDateDeNaissance: 10,
+        jourDateDeNaissance: 15,
+        codeInseeLieuDeNaissance: nil,
+        prenoms: ["David"],
+        sexe: "M",
+        nomUsuel: "Heinemeier Hansson",
+        **original_pivot_identity,
+      },
+      quotient_familial: {
+        regime: "CNAF",
+        allocataires: [
+          {
+            nomNaissance: "DUBOIS",
+            nomUsuel: "DUBOIS",
+            prenoms: "ANGELA",
+            anneeDateDeNaissance: "1962",
+            moisDateDeNaissance: "08",
+            jourDateDeNaissance: "24",
+            sexe: "F",
+          },
+        ],
+        enfants: [
+          {
+            nomNaissance: "Dujardin",
+            nomUsuel: "Dujardin",
+            prenoms: "Jean",
+            sexe: "M",
+            anneeDateDeNaissance: "2016",
+            moisDateDeNaissance: "12",
+            jourDateDeNaissance: "13",
+          },
+        ],
+        quotientFamilial: 2550,
+        annee: 2024,
+        mois: 2,
+        version: "v2",
+      },
+    }
+  end
 
   describe "to_h" do
     it "returns the shipment data as a hash" do
       expect(shipment_data.to_h.with_indifferent_access).to match(
-        external_id: "external_id",
-        pivot_identity: {
-          codePaysLieuDeNaissance: "99135",
-          anneeDateDeNaissance: 1979,
-          moisDateDeNaissance: 10,
-          jourDateDeNaissance: 15,
-          codeInseeLieuDeNaissance: nil,
-          prenoms: ["David"],
-          sexe: "M",
-          nomUsuel: "Heinemeier Hansson",
-        },
-        quotient_familial: {
-          regime: "CNAF",
-          allocataires: [
-            {
-              nomNaissance: "DUBOIS",
-              nomUsuel: "DUBOIS",
-              prenoms: "ANGELA",
-              anneeDateDeNaissance: "1962",
-              moisDateDeNaissance: "08",
-              jourDateDeNaissance: "24",
-              sexe: "F",
-            },
-          ],
-          enfants: [
-            {
-              nomNaissance: "Dujardin",
-              nomUsuel: "Dujardin",
-              prenoms: "Jean",
-              sexe: "M",
-              anneeDateDeNaissance: "2016",
-              moisDateDeNaissance: "12",
-              jourDateDeNaissance: "13",
-            },
-          ],
-          quotientFamilial: 2550,
-          annee: 2024,
-          mois: 2,
-          version: "v2",
-        }
+        expected_hash.with_indifferent_access
       )
-    end
-  end
-
-  describe "#to_json" do
-    subject(:to_json) { shipment_data.to_json }
-
-    let(:expected_json) do
-      '{"external_id":"external_id","pivot_identity":{"codePaysLieuDeNaissance":"99135","anneeDateDeNaissance":1979,"moisDateDeNaissance":10,"jourDateDeNaissance":15,"codeInseeLieuDeNaissance":null,"prenoms":["David"],"sexe":"M","nomUsuel":"Heinemeier Hansson"},"quotient_familial":{"version":"v2","regime":"CNAF","quotientFamilial":2550,"annee":2024,"mois":2,"allocataires":[{"nomNaissance":"DUBOIS","nomUsuel":"DUBOIS","prenoms":"ANGELA","anneeDateDeNaissance":"1962","moisDateDeNaissance":"08","jourDateDeNaissance":"24","sexe":"F"}],"enfants":[{"nomNaissance":"Dujardin","nomUsuel":"Dujardin","prenoms":"Jean","sexe":"M","anneeDateDeNaissance":"2016","moisDateDeNaissance":"12","jourDateDeNaissance":"13"}]}}'
-    end
-
-    it "returns the shipment data as a json" do
-      expect(to_json).to eq(expected_json)
-    end
-  end
-
-  describe "#to_xml" do
-    subject(:to_xml) { shipment_data.to_xml }
-
-    let(:expected_xml) do
-      <<~XML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <hash>
-          <external-id>external_id</external-id>
-          <pivot-identity>
-            <codePaysLieuDeNaissance>99135</codePaysLieuDeNaissance>
-            <anneeDateDeNaissance type="integer">1979</anneeDateDeNaissance>
-            <moisDateDeNaissance type="integer">10</moisDateDeNaissance>
-            <jourDateDeNaissance type="integer">15</jourDateDeNaissance>
-            <codeInseeLieuDeNaissance nil="true"/>
-            <prenoms type="array">
-              <prenom>David</prenom>
-            </prenoms>
-            <sexe>M</sexe>
-            <nomUsuel>Heinemeier Hansson</nomUsuel>
-          </pivot-identity>
-          <quotient-familial>
-            <version>v2</version>
-            <regime>CNAF</regime>
-            <quotientFamilial type="integer">2550</quotientFamilial>
-            <annee type="integer">2024</annee>
-            <mois type="integer">2</mois>
-            <allocataires type="array">
-              <allocataire>
-                <nomNaissance>DUBOIS</nomNaissance>
-                <nomUsuel>DUBOIS</nomUsuel>
-                <prenoms>ANGELA</prenoms>
-                <anneeDateDeNaissance>1962</anneeDateDeNaissance>
-                <moisDateDeNaissance>08</moisDateDeNaissance>
-                <jourDateDeNaissance>24</jourDateDeNaissance>
-                <sexe>F</sexe>
-              </allocataire>
-            </allocataires>
-            <enfants type="array">
-              <enfant>
-                <nomNaissance>Dujardin</nomNaissance>
-                <nomUsuel>Dujardin</nomUsuel>
-                <prenoms>Jean</prenoms>
-                <sexe>M</sexe>
-                <anneeDateDeNaissance>2016</anneeDateDeNaissance>
-                <moisDateDeNaissance>12</moisDateDeNaissance>
-                <jourDateDeNaissance>13</jourDateDeNaissance>
-              </enfant>
-            </enfants>
-          </quotient-familial>
-        </hash>
-      XML
-    end
-
-    it "returns the shipment data as a xml" do
-      expect(to_xml).to eq(expected_xml)
     end
   end
 

--- a/spec/models/shipment_data_spec.rb
+++ b/spec/models/shipment_data_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe ShipmentData, type: :model do
         prenoms: ["David"],
         sexe: "M",
         nomUsuel: "Heinemeier Hansson",
-        **original_pivot_identity,
+        family_name: "TESTMAN",
+        given_name: "Johnny Paul René",
+        gender: "male",
+        birthdate: "1989-10-08",
+        birthplace: "75107",
+        birthcountry: "99100",
       },
       quotient_familial: {
         regime: "CNAF",

--- a/spec/organizers/store_quotient_familial_spec.rb
+++ b/spec/organizers/store_quotient_familial_spec.rb
@@ -14,10 +14,12 @@ RSpec.describe StoreQuotientFamilial, type: :organizer do
     subject(:organizer) { described_class.call(**params) }
 
     let(:pivot_identity) { PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male) }
+    let(:original_pivot_identity) { build(:original_pivot_identity) }
     let(:params) do
       {
         quotient_familial:,
         pivot_identity:,
+        original_pivot_identity:,
         collectivity:,
         user:,
       }

--- a/spec/organizers/upload_quotient_familial_to_hubee_spec.rb
+++ b/spec/organizers/upload_quotient_familial_to_hubee_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe UploadQuotientFamilialToHubEE, type: :organizer do
     subject { described_class.call(**params) }
 
     let(:pivot_identity) { PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male) }
+    let(:original_pivot_identity) { build(:original_pivot_identity) }
     let(:quotient_familial) { FactoryBot.build(:quotient_familial_v2_payload) }
     let(:collectivity) { create(:collectivity) }
     let(:params) do
       {
         quotient_familial:,
         pivot_identity:,
+        original_pivot_identity:,
         collectivity:,
       }
     end


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-3428/mettre-cote-a-cote-les-champs-renommes-et-les-champs-originaux

Pour l'instant on ajoute simplement les champs originaux dans le fichier envoyé.

:warning: **On déploiera ça juste en sandbox en attendant que les éditeurs se branchent sur les nouveaux champs**