### PR TITLE
Remove deprecated pivot identity fields

### DIFF
--- a/app/jobs/populate_hubee_sandbox_job.rb
+++ b/app/jobs/populate_hubee_sandbox_job.rb
@@ -30,7 +30,7 @@ class PopulateHubEESandboxJob < ApplicationJob
   private
 
   def pivot_identity
-    PivotIdentity.new(first_names: ["David"], last_name: "Heinemeier Hansson", birth_country: "99135", birthplace: nil, birthdate: Date.new(1979, 10, 15), gender: :male)
+    PivotIdentity.new(**FranceConnect::IdentityMapper.normalize(original_pivot_identity))
   end
 
   def original_pivot_identity

--- a/app/models/shipment_data.rb
+++ b/app/models/shipment_data.rb
@@ -11,18 +11,8 @@ class ShipmentData
   def to_h
     {
       external_id: external_id,
-      pivot_identity: {
-        codePaysLieuDeNaissance: pivot_identity.birth_country,
-        anneeDateDeNaissance: pivot_identity.birthdate.year,
-        moisDateDeNaissance: pivot_identity.birthdate.month,
-        jourDateDeNaissance: pivot_identity.birthdate.day,
-        codeInseeLieuDeNaissance: pivot_identity.birthplace,
-        prenoms: pivot_identity.first_names,
-        sexe: (pivot_identity.gender == :female) ? "F" : "M",
-        nomUsuel: pivot_identity.last_name,
-        **original_pivot_identity,
-      },
-      quotient_familial:,
+      pivot_identity: original_pivot_identity,
+      quotient_familial: quotient_familial,
     }
   end
 

--- a/spec/models/shipment_data_spec.rb
+++ b/spec/models/shipment_data_spec.rb
@@ -9,14 +9,6 @@ RSpec.describe ShipmentData, type: :model do
     {
       external_id: "external_id",
       pivot_identity: {
-        codePaysLieuDeNaissance: "99135",
-        anneeDateDeNaissance: 1979,
-        moisDateDeNaissance: 10,
-        jourDateDeNaissance: 15,
-        codeInseeLieuDeNaissance: nil,
-        prenoms: ["David"],
-        sexe: "M",
-        nomUsuel: "Heinemeier Hansson",
         family_name: "TESTMAN",
         given_name: "Johnny Paul René",
         gender: "male",


### PR DESCRIPTION
Closes https://linear.app/pole-api/issue/API-3432/planifier-de-retirer-les-anciens-champs-de-lidentite-pivot-le-11