### PR TITLE
Improve api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ group :test do
 end
 
 gem "good_job", "~> 3.99"
+
+gem "rack-cors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.7)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required
@@ -552,6 +554,7 @@ DEPENDENCIES
   pg (~> 1.5)
   prawn
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.2.1)
   rails-i18n (~> 7.0.0)
   rqrcode (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # README
 
+Pour l'API, consulter le [swagger](/docs/swagger.yaml)
+
 ## Install project
 
 ### Database setup

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "/api/*", headers: :any, methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.3
+info:
+  title: Swagger quotient-familial.numerique.gouv.fr - OpenAPI 3.0
+  description: |-
+    # Le service
+
+    Les cantines, transports ou aides spécifiques proposés par les collectivités sont souvent tarifés ou alloués selon la situation familiale et les ressources des particuliers.
+
+    Le service [quotient-familial.numerique.gouv.fr](https://quotient-familial.numerique.gouv.fr) vous permet de transmettre de façon sécurisée vos données d’identité permettant à votre collectivité de récupérer instantanément votre quotient familial CAF ou MSA auprès de l’administration détenant cette information.
+
+    # L'API
+    Cette API sert à savoir quelles sont les communes disponibles sur [quotient-familial.numerique.gouv.fr](https://quotient-familial.numerique.gouv.fr).
+    
+    Aucune clef d'API requise.
+    
+  version: 1.0.0
+servers:
+  - url: https://quotient-familial.numerique.gouv.fr/api
+paths:
+  /collectivites:
+    get:
+      tags:
+        - collectivités
+      summary: Liste des collectivités
+      description: Liste des collectivités disponibles sur quotient-familial.gouv.fr
+      operationId: getCollectivities
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Collectivity'
+components:
+  schemas:
+    Collectivity:
+      type: object
+      properties:
+        siret:
+          type: string
+          example: "1021290146600012"
+        name:
+          type: string
+          example: "COMMUNE DE MELGVEN"
+        code_cog:
+          type: string
+          example: "29146"
+    


### PR DESCRIPTION
J'ai voulu faire le swagger de notre API pour pas être un gros shlag quand je communique dessus, et en voulant cliquer sur le bouton du swagger pour tester l'API je me suis rendu compte qu'on autorisait pas les requêtes provenant d'autres origines, ce qui pourrait être pratique.

Closes https://linear.app/pole-api/issue/API-3680/allow-cors-and-make-a-swagger-for-api