### PR TITLE
Add missing applicant data to HubEE subscription payload

### DIFF
--- a/app/controllers/api/datapass_webhooks_controller.rb
+++ b/app/controllers/api/datapass_webhooks_controller.rb
@@ -3,11 +3,15 @@ class Api::DatapassWebhooksController < ActionController::API
 
   def create
     if event == "approve"
-      SetupCollectivityJob.perform_later(datapass_id:, collectivity_siret:, collectivity_email:, service_provider:)
+      SetupCollectivityJob.perform_later(datapass_id:, collectivity_siret:, collectivity_email:, service_provider:, applicant:)
     end
   end
 
   private
+
+  def applicant
+    webhook_params.dig("data", "applicant")
+  end
 
   def collectivity_email
     webhook_params.dig("data", "applicant", "email")

--- a/app/interactors/datapass_webhook/create_hubee_subscription.rb
+++ b/app/interactors/datapass_webhook/create_hubee_subscription.rb
@@ -1,5 +1,5 @@
 class DatapassWebhook::CreateHubEESubscription < BaseInteractor
-  delegate :collectivity_email, :datapass_id, :hubee_organization_payload, :service_provider, to: :context
+  delegate :collectivity_email, :datapass_id, :hubee_organization_payload, :service_provider, :applicant, to: :context
 
   def call
     context.hubee_subscription_payload = create_subscription_on_hubee
@@ -7,8 +7,18 @@ class DatapassWebhook::CreateHubEESubscription < BaseInteractor
 
   private
 
+  def applicant_payload
+    {
+      email: applicant["email"],
+      firstName: applicant["given_name"],
+      lastName: applicant["family_name"],
+      function: applicant["job_title"],
+      phoneNumber: applicant["phone_number"].gsub(/[\s\.\-]/, ""),
+    }
+  end
+
   def create_subscription_on_hubee
-    hubee_api_client.create_subscription(datapass_id:, collectivity_email:, organization_payload: hubee_organization_payload, process_code:, editor_payload:)
+    hubee_api_client.create_subscription(datapass_id:, collectivity_email:, organization_payload: hubee_organization_payload, process_code:, editor_payload:, applicant_payload:)
   end
 
   def editor_organization

--- a/app/jobs/setup_collectivity_job.rb
+++ b/app/jobs/setup_collectivity_job.rb
@@ -1,6 +1,6 @@
 class SetupCollectivityJob < ApplicationJob
-  def perform(datapass_id:, collectivity_siret:, collectivity_email:, service_provider:)
+  def perform(datapass_id:, collectivity_siret:, collectivity_email:, service_provider:, applicant:)
     organization = Organization.new(collectivity_siret)
-    DatapassWebhook::SetupCollectivity.call(datapass_id:, organization:, collectivity_email:, service_provider:)
+    DatapassWebhook::SetupCollectivity.call(datapass_id:, organization:, collectivity_email:, service_provider:, applicant:)
   end
 end

--- a/lib/hubee/admin_api.rb
+++ b/lib/hubee/admin_api.rb
@@ -38,8 +38,8 @@ class HubEE::AdminApi < HubEE::Base
     raise
   end
 
-  def create_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, editor_payload: {})
-    subscription_payload = find_or_create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:)
+  def create_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, editor_payload: {}, applicant_payload: {})
+    subscription_payload = find_or_create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, applicant_payload:)
     activate_subscription(subscription_payload, editor_payload)
     subscription_payload
   end
@@ -96,7 +96,7 @@ class HubEE::AdminApi < HubEE::Base
     ).body
   end
 
-  def create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:) # rubocop:disable Metrics/AbcSize
+  def create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, applicant_payload:) # rubocop:disable Metrics/AbcSize
     http_connection.post(
       "#{host}/referential/v1/subscriptions",
       {
@@ -110,9 +110,7 @@ class HubEE::AdminApi < HubEE::Base
         },
         email: collectivity_email,
         status: "Inactif",
-        localAdministrator: {
-          email: collectivity_email,
-        },
+        localAdministrator: applicant_payload,
         validateDateTime: DateTime.now.iso8601,
         updateDateTime: DateTime.now.iso8601,
       }.to_json,
@@ -124,8 +122,8 @@ class HubEE::AdminApi < HubEE::Base
     raise
   end
 
-  def find_or_create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:)
-    create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:)
+  def find_or_create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, applicant_payload: {})
+    create_inactive_subscription(datapass_id:, collectivity_email:, organization_payload:, process_code:, applicant_payload:)
   rescue AlreadyExists
     find_subscription(organization_payload, process_code)
   end

--- a/spec/organizers/datapass_webhook/setup_collectivity_spec.rb
+++ b/spec/organizers/datapass_webhook/setup_collectivity_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe DatapassWebhook::SetupCollectivity, type: :organizer do
         organization:,
         collectivity_email: "collectivity@test.fr",
         service_provider: {},
+        applicant:,
+      }
+    end
+    let(:applicant) do
+      {
+        "email" => "email@test.com",
+        "given_name" => "John",
+        "family_name" => "Doe",
+        "job_title" => "Mayor",
+        "phone_number" => "+33123456789",
       }
     end
 


### PR DESCRIPTION
Users were not correcly setup because the payload was missing some of their data. This prevented the account form being created on HubEE's side and users were thus not receiving any email.