### PR TITLE
Règle les tests cassés à cause d'un changement rubocop

### DIFF
--- a/app/controllers/collectivities_controller.rb
+++ b/app/controllers/collectivities_controller.rb
@@ -40,7 +40,9 @@ class CollectivitiesController < ApplicationController
   end
 
   def set_collectivity
-    @collectivity = CollectivityDecorator.new(Collectivity.active.find_by!(siret: params.expect(:id)))
+    # rubocop:disable Rails/StrongParametersExpect -- id may be absent here (the "select" action is reached from the form's submit with no collectivity chosen); params.expect would raise ParameterMissing instead of letting find_by! raise the rescued RecordNotFound
+    @collectivity = CollectivityDecorator.new(Collectivity.active.find_by!(siret: params[:id]))
+    # rubocop:enable Rails/StrongParametersExpect
   rescue ActiveRecord::RecordNotFound
     flash[:error] = {
       title: t(".not_found_error.title"),


### PR DESCRIPTION
## Problème

Le commit `d39f08d "Lint"` a appliqué l'autocorrection `rubocop -A` de la règle `Rails/StrongParametersExpect`, transformant `params[:id]` en `params.expect(:id)` dans `CollectivitiesController#set_collectivity`. Cela casse l'e2e sur `main` ([run](https://github.com/etalab/formulaire-qf/actions/runs/26757987908)).

## Cause

`set_collectivity` tourne en `before_action` sur `select`/`show`/`no_france_connect`. L'action `select` est atteinte depuis le submit « Suivant » du formulaire de sélection, où `id` peut être **vide/absent** :

- `params[:id]` → `nil` → `find_by!(siret: nil)` → `RecordNotFound` → **rescue** → flash « Choisir une collectivité ».
- `params.expect(:id)` → `ActionController::ParameterMissing` non rattrapé → 500.

`Rails/StrongParametersExpect` est donc un faux positif ici.

## Fix

Retour à `params[:id]` avec un `rubocop:disable` inline justifié.

Garde-fou de non-régression : `features/sélectionner_une_commune.feature:26` (« Je ne peux pas ne sélectionner aucune collectivité »).