### PR TITLE
Only delete our own HubEE notifications

### DIFF
--- a/app/interactors/process_hubee_notification.rb
+++ b/app/interactors/process_hubee_notification.rb
@@ -20,7 +20,9 @@ class ProcessHubEENotification < BaseInteractor
   end
 
   after do
-    session.delete_notification(notification_id: notification.id)
+    # The /notifications queue is shared by every processCode of the OSL:
+    # deleting foreign notifications would destroy them for their consumer.
+    session.delete_notification(notification_id: notification.id) if notification.formulaire_qf?
   end
 
   private

--- a/spec/interactors/process_hubee_notification_spec.rb
+++ b/spec/interactors/process_hubee_notification_spec.rb
@@ -189,7 +189,15 @@ RSpec.describe ProcessHubEENotification, type: :interactor do
     context "when the notification is not for FormulaireQF" do
       let(:process_code) { "CertDC" }
 
-      it_behaves_like "an ignored notification"
+      it "leaves the notification in the queue for its owner" do
+        expect(session).not_to receive(:delete_notification)
+        interactor
+      end
+
+      it "does not update the event" do
+        expect(session).not_to receive(:update_event)
+        interactor
+      end
     end
   end
 end


### PR DESCRIPTION
The OSL's `/notifications` queue is shared across processCodes; the `after` hook deleted every polled notification, including `ProactiviteCnousBoursiers` ones consumed by `relais`. Scope the deletion to `FormulaireQF`.

Coexistence prerequisite for API-6996 → https://linear.app/pole-api/issue/API-6996

🤖 Generated with [Claude Code](https://claude.com/claude-code)